### PR TITLE
Feat/context closed middleware

### DIFF
--- a/src/TinyDispatcher/TinyDispatcher.csproj
+++ b/src/TinyDispatcher/TinyDispatcher.csproj
@@ -46,11 +46,21 @@
   </ItemGroup>
   <PropertyGroup>
     <PackageReleaseNotes>
-      - Added TinyDispatcherGeneratorOptions assembly attribute (preferred over MSBuild properties)
-      - Source generator now reads options from compilation attribute first, MSBuild props fallback
-      - Added unit test covering attribute options resolution when AnalyzerConfigOptionsProvider is null
-      - Configuration is now safer by design: core framework namespace is no longer user-configurable
+      Added support for context-closed middleware.
+
+      Middleware can now be defined in two supported shapes:
+      - ICommandMiddleware&lt;TCommand, TContext&gt; (fully open, classic)
+      - ICommandMiddleware&lt;TCommand&gt; with context inferred at compile time
+
+      Context-closed middleware is strictly validated at build time:
+      - must be open generic with arity 1 or 2
+      - arity-1 middleware must implement exactly one ICommandMiddleware&lt;TCommand, TContext&gt;
+      - context type must exactly match the one configured via UseTinyDispatcher&lt;TContext&gt;
+
+      Generated pipelines correctly close middleware based on arity.
+      No breaking changes. Existing middleware continues to work unchanged.
     </PackageReleaseNotes>
+
   </PropertyGroup>
 
 </Project>

--- a/tests/TinyDispatcher.IntegrationTests/EndToEndDispatchTests.cs
+++ b/tests/TinyDispatcher.IntegrationTests/EndToEndDispatchTests.cs
@@ -9,6 +9,7 @@ using TinyDispatcher.Dispatching;
 using TinyDispatcher.Internal;
 using Xunit;
 
+namespace TinyDispatcher.IntegrationTests;
 public sealed class EndToEndDispatchTests
 {
     private sealed record CreateThing(string Name) : ICommand;

--- a/tests/TinyDispatcher.UnitTests/SourceGen/OptionsProviderTests.cs
+++ b/tests/TinyDispatcher.UnitTests/SourceGen/OptionsProviderTests.cs
@@ -5,11 +5,10 @@ using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using TinyDispatcher;
 using TinyDispatcher.SourceGen.Internal;
 using Xunit;
 
-namespace TinyDispatcher.UnitTets;
+namespace TinyDispatcher.UnitTests.SourceGen;
 
 public sealed class OptionsProviderTests
 {

--- a/tests/TinyDispatcher.UnitTests/TinyDispatcher.UnitTests.csproj
+++ b/tests/TinyDispatcher.UnitTests/TinyDispatcher.UnitTests.csproj
@@ -46,9 +46,7 @@
     <ProjectReference Include="..\..\src\TinyDispatcher\TinyDispatcher.csproj" />
 
     <!-- Source generator: referenced as analyzer ONLY -->
-    <ProjectReference Include="..\..\src\TinyDispatcher.SourceGen\TinyDispatcher.SourceGen.csproj"
-                      OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="true" />
+    <ProjectReference Include="..\..\src\TinyDispatcher.SourceGen\TinyDispatcher.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
 Added support for context-closed middleware.

 Middleware can now be defined in two supported shapes:
 - ICommandMiddleware&lt;TCommand, TContext&gt; (fully open, classic)
 - ICommandMiddleware&lt;TCommand&gt; with context inferred at compile time

 Context-closed middleware is strictly validated at build time:
 - must be open generic with arity 1 or 2
 - arity-1 middleware must implement exactly one ICommandMiddleware&lt;TCommand, TContext&gt;
 - context type must exactly match the one configured via UseTinyDispatcher&lt;TContext&gt;

 Generated pipelines correctly close middleware based on arity.
 No breaking changes. Existing middleware continues to work unchanged.