### PR TITLE
Feat/single pipeline contract

### DIFF
--- a/src/TinyDispatcher/Dispatching/Dispatcher.cs
+++ b/src/TinyDispatcher/Dispatching/Dispatcher.cs
@@ -35,8 +35,8 @@ public sealed class Dispatcher<TContext> : IDispatcher<TContext>
 
         var ctx = await _contextFactory.CreateAsync(ct).ConfigureAwait(false);
             
-        var pipeline = ResolvePipeline<TCommand>();
-        
+        var pipeline = _services.GetService<ICommandPipeline<TCommand, TContext>>();
+
         if (pipeline is null)
         {
             await handler.HandleAsync(command, ctx, ct);
@@ -59,20 +59,5 @@ public sealed class Dispatcher<TContext> : IDispatcher<TContext>
                 $"No handler registered for query '{typeof(TQuery).FullName}'.");
         }
         return handler.HandleAsync(query, ct);
-    }
-
-    private ICommandPipeline<TCommand, TContext>? ResolvePipeline<TCommand>()
-    where TCommand : ICommand
-    {
-        ICommandPipeline<TCommand, TContext>? p =
-            _services.GetService<ICommandPipeline<TCommand, TContext>>();
-
-        if (p is null)
-            p = _services.GetService<IPolicyCommandPipeline<TCommand, TContext>>();
-
-        if (p is null)
-            p = _services.GetService<IGlobalCommandPipeline<TCommand, TContext>>();
-
-        return p;
     }
 }

--- a/src/TinyDispatcher/Pipeline/ICommandPipelines.cs
+++ b/src/TinyDispatcher/Pipeline/ICommandPipelines.cs
@@ -8,18 +8,18 @@ public interface ICommandPipeline<TCommand, TContext> where TCommand : ICommand
 }
 
 
-/// <summary>
-/// Policy pipeline for a command. Lower precedence than ICommandPipeline, higher than global.
-/// </summary>
-public interface IPolicyCommandPipeline<TCommand, TContext> : ICommandPipeline<TCommand, TContext>
-    where TCommand : ICommand
-{
-}
+///// <summary>
+///// Policy pipeline for a command. Lower precedence than ICommandPipeline, higher than global.
+///// </summary>
+//public interface IPolicyCommandPipeline<TCommand, TContext> : ICommandPipeline<TCommand, TContext>
+//    where TCommand : ICommand
+//{
+//}
 
-/// <summary>
-/// Global pipeline for a command. Lowest precedence (still above direct handler call).
-/// </summary>
-public interface IGlobalCommandPipeline<TCommand, TContext> : ICommandPipeline<TCommand, TContext>
-    where TCommand : ICommand
-{
-}
+///// <summary>
+///// Global pipeline for a command. Lowest precedence (still above direct handler call).
+///// </summary>
+//public interface IGlobalCommandPipeline<TCommand, TContext> : ICommandPipeline<TCommand, TContext>
+//    where TCommand : ICommand
+//{
+//}

--- a/src/TinyDispatcher/Pipeline/ICommandPipelines.cs
+++ b/src/TinyDispatcher/Pipeline/ICommandPipelines.cs
@@ -6,20 +6,3 @@ public interface ICommandPipeline<TCommand, TContext> where TCommand : ICommand
 {
     ValueTask ExecuteAsync(TCommand command, TContext context, ICommandHandler<TCommand, TContext> handler, CancellationToken ct = default);
 }
-
-
-///// <summary>
-///// Policy pipeline for a command. Lower precedence than ICommandPipeline, higher than global.
-///// </summary>
-//public interface IPolicyCommandPipeline<TCommand, TContext> : ICommandPipeline<TCommand, TContext>
-//    where TCommand : ICommand
-//{
-//}
-
-///// <summary>
-///// Global pipeline for a command. Lowest precedence (still above direct handler call).
-///// </summary>
-//public interface IGlobalCommandPipeline<TCommand, TContext> : ICommandPipeline<TCommand, TContext>
-//    where TCommand : ICommand
-//{
-//}

--- a/src/TinyDispatcher/TinyDispatcher.csproj
+++ b/src/TinyDispatcher/TinyDispatcher.csproj
@@ -114,12 +114,38 @@
             =&gt; runtime.NextAsync(command, context, ct);
             &lt;/pre&gt;
 
+            &lt;h2&gt;Pipeline Contract Simplification (Breaking)&lt;/h2&gt;
+
+            &lt;p&gt;
+            The dispatcher no longer performs runtime pipeline precedence resolution.
+            Global, Policy, and Per-command pipelines are now unified under a single
+            &lt;code&gt;ICommandPipeline&lt;TCommand,TContext&gt;&lt;/code&gt; contract.
+            &lt;/p&gt;
+
+            &lt;h3&gt;What changed&lt;/h3&gt;
+            &lt;ul&gt;
+            &lt;li&gt;Removed &lt;code&gt;IPolicyCommandPipeline&lt;,&gt;&lt;/code&gt;.&lt;/li&gt;
+            &lt;li&gt;Removed &lt;code&gt;IGlobalCommandPipeline&lt;,&gt;&lt;/code&gt;.&lt;/li&gt;
+            &lt;li&gt;Dispatcher now resolves a single &lt;code&gt;ICommandPipeline&lt;TCommand,TContext&gt;&lt;/code&gt;.&lt;/li&gt;
+            &lt;li&gt;Pipeline precedence (Per-command → Policy → Global) is enforced at compile-time by source generation.&lt;/li&gt;
+            &lt;li&gt;Reduced DI lookups and removed runtime branching in the dispatch path.&lt;/li&gt;
+            &lt;/ul&gt;
+
+            &lt;h3&gt;Migration guide&lt;/h3&gt;
+            &lt;p&gt;
+            If you were implementing &lt;code&gt;IPolicyCommandPipeline&lt;,&gt;&lt;/code&gt; or
+            &lt;code&gt;IGlobalCommandPipeline&lt;,&gt;&lt;/code&gt;, replace them with
+            &lt;code&gt;ICommandPipeline&lt;TCommand,TContext&gt;&lt;/code&gt;.
+            &lt;/p&gt;
+
             &lt;h3&gt;Notes&lt;/h3&gt;
             &lt;ul&gt;
-            &lt;li&gt;This is a prerelease hardening step ahead of v1.0; further cleanup may follow.&lt;/li&gt;
-            &lt;li&gt;If you maintain custom middleware, you must update it to the new runtime-based signature.&lt;/li&gt;
+            &lt;li&gt;This change simplifies the public API surface and reduces runtime complexity.&lt;/li&gt;
+            &lt;li&gt;Pipeline resolution is now deterministic and fully generator-driven.&lt;/li&gt;
+            &lt;li&gt;This is part of the final hardening phase toward v1.0.&lt;/li&gt;
             &lt;/ul&gt;
           </PackageReleaseNotes>
+
 
         </PackageReleaseNotes>
       </PropertyGroup>

--- a/tests/TinyDispatcher.UnitTests/PipelineSelectionTests.cs
+++ b/tests/TinyDispatcher.UnitTests/PipelineSelectionTests.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using TinyDispatcher;
@@ -14,14 +13,12 @@ namespace TinyDispatcher.UnitTets
     public sealed class PipelineSelectionTests
     {
         [Fact]
-        public async Task Command_pipeline_is_chosen_over_policy_and_global()
+        public async Task Pipeline_is_used_when_registered()
         {
             // Arrange
             using var sp = BuildProvider(services =>
             {
                 services.AddTransient<ICommandPipeline<TestCommand, TestContext>, CommandPipeline>();
-                services.AddTransient<IPolicyCommandPipeline<TestCommand, TestContext>, PolicyPipeline>();
-                services.AddTransient<IGlobalCommandPipeline<TestCommand, TestContext>, GlobalPipeline>();
             });
 
             var dispatcher = sp.GetRequiredService<IDispatcher<TestContext>>();
@@ -31,20 +28,17 @@ namespace TinyDispatcher.UnitTets
             await dispatcher.DispatchAsync(new TestCommand(string.Empty), CancellationToken.None);
 
             // Assert
-            Assert.True(tracker.CommandPipelineCalled);
-            Assert.False(tracker.PolicyPipelineCalled);
-            Assert.False(tracker.GlobalPipelineCalled);
+            Assert.True(tracker.PipelineCalled);
             Assert.True(tracker.HandlerCalled);
         }
 
         [Fact]
-        public async Task Policy_pipeline_is_chosen_over_global_when_no_command_pipeline()
+        public async Task Handler_is_called_directly_when_no_pipeline_registered()
         {
             // Arrange
             using var sp = BuildProvider(services =>
             {
-                services.AddTransient<IPolicyCommandPipeline<TestCommand, TestContext>, PolicyPipeline>();
-                services.AddTransient<IGlobalCommandPipeline<TestCommand, TestContext>, GlobalPipeline>();
+                // no pipeline
             });
 
             var dispatcher = sp.GetRequiredService<IDispatcher<TestContext>>();
@@ -54,31 +48,7 @@ namespace TinyDispatcher.UnitTets
             await dispatcher.DispatchAsync(new TestCommand("x"), CancellationToken.None);
 
             // Assert
-            Assert.False(tracker.CommandPipelineCalled);
-            Assert.True(tracker.PolicyPipelineCalled);
-            Assert.False(tracker.GlobalPipelineCalled);
-            Assert.True(tracker.HandlerCalled);
-        }
-
-        [Fact]
-        public async Task Global_pipeline_is_used_when_no_command_or_policy_pipeline()
-        {
-            // Arrange
-            using var sp = BuildProvider(services =>
-            {
-                services.AddTransient<IGlobalCommandPipeline<TestCommand, TestContext>, GlobalPipeline>();
-            });
-
-            var dispatcher = sp.GetRequiredService<IDispatcher<TestContext>>();
-            var tracker = sp.GetRequiredService<CallTracker>();
-
-            // Act
-            await dispatcher.DispatchAsync(new TestCommand("x"), CancellationToken.None);
-
-            // Assert
-            Assert.False(tracker.CommandPipelineCalled);
-            Assert.False(tracker.PolicyPipelineCalled);
-            Assert.True(tracker.GlobalPipelineCalled);
+            Assert.False(tracker.PipelineCalled);
             Assert.True(tracker.HandlerCalled);
         }
 
@@ -89,7 +59,8 @@ namespace TinyDispatcher.UnitTets
             // Shared fixtures
             services.AddSingleton<CallTracker>();
             services.AddScoped<IContextFactory<TestContext>, TestContextFactory>();
-            services.AddTransient<ICommandHandler<TestCommand,TestContext>,TestHandler>();
+            services.AddTransient<ICommandHandler<TestCommand, TestContext>, TestHandler>();
+
             // Pipelines for this test
             configurePipelines(services);
 

--- a/tests/TinyDispatcher.UnitTests/TestDomain.cs
+++ b/tests/TinyDispatcher.UnitTests/TestDomain.cs
@@ -1,7 +1,16 @@
-﻿using System;
+﻿// File: tests/TinyDispatcher.UnitTests/TestDomain.cs
+// CLEANED UP for single pipeline contract (ICommandPipeline<TCommand,TContext> only)
+//
+// Changes:
+// - Removed unused usings
+// - Removed PolicyPipeline / GlobalPipeline test doubles (they don't make sense with single pipeline contract)
+// - Simplified CallTracker (only what runtime tests can assert now)
+// - Kept SourceGen-related policy + middlewares (Global/Policy/PerCommand) for execution-order tests
+// - Kept handlers + context factory
+// - Kept CommandPipeline (used by runtime DI tests)
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using TinyDispatcher.Context;
 using TinyDispatcher.Pipeline;
@@ -10,25 +19,31 @@ namespace TinyDispatcher.UnitTests
 {
     public sealed class CallTracker
     {
-        public bool CommandPipelineCalled { get; set; }
-        public bool PolicyPipelineCalled { get; set; }
-        public bool GlobalPipelineCalled { get; set; }
+        public bool PipelineCalled { get; set; }
         public bool HandlerCalled { get; set; }
     }
 
-    public sealed record TestCommand(string value) : ICommand;
+    public sealed record TestCommand(string Value) : ICommand;
     public sealed record OtherCommand(string Value) : ICommand;
-
     public sealed record PolicyOnlyCommand(string Value) : ICommand;
+
+    // -------------------------------------------------------------------------
+    // Policy declarations (attributes read by SourceGen)
+    // -------------------------------------------------------------------------
 
     [TinyPolicy]
     [UseMiddleware(typeof(PolicyLogMiddleware<,>))]
     [ForCommand(typeof(PolicyOnlyCommand))]
     internal sealed class PolicyOnlyPolicy { }
 
-    // -----------------------------------------------------------------------------
-    // Test context (we want to assert exact execution order)
-    // -----------------------------------------------------------------------------
+    [TinyPolicy]
+    [UseMiddleware(typeof(PolicyLogMiddleware<,>))]
+    [ForCommand(typeof(TestCommand))]
+    internal sealed class CheckoutPolicy { }
+
+    // -------------------------------------------------------------------------
+    // Test context (we assert exact execution order in SourceGen tests)
+    // -------------------------------------------------------------------------
     public sealed class TestContext
     {
         public List<string> Log { get; } = new();
@@ -36,6 +51,18 @@ namespace TinyDispatcher.UnitTests
         public CancellationToken SeenByHandler { get; internal set; }
     }
 
+    // -------------------------------------------------------------------------
+    // Context factory
+    // -------------------------------------------------------------------------
+    public sealed class TestContextFactory : IContextFactory<TestContext>
+    {
+        public ValueTask<TestContext> CreateAsync(CancellationToken ct = default)
+            => new(new TestContext { SeenByFactory = ct });
+    }
+
+    // -------------------------------------------------------------------------
+    // Handlers
+    // -------------------------------------------------------------------------
     internal sealed class OtherCommandHandler : ICommandHandler<OtherCommand, TestContext>
     {
         public Task HandleAsync(OtherCommand command, TestContext ctx, CancellationToken ct = default)
@@ -54,10 +81,44 @@ namespace TinyDispatcher.UnitTests
         }
     }
 
+    public sealed class TestHandler : ICommandHandler<TestCommand, TestContext>
+    {
+        private readonly CallTracker _tracker;
 
-    // -----------------------------------------------------------------------------
-    // Open-generic middlewares (generator expects open generic types)
-    // -----------------------------------------------------------------------------
+        public TestHandler(CallTracker tracker) => _tracker = tracker;
+
+        public Task HandleAsync(TestCommand command, TestContext ctx, CancellationToken ct = default)
+        {
+            _tracker.HandlerCalled = true;
+            ctx.SeenByHandler = ct;
+            ctx.Log.Add("handler:TestCommand");
+            return Task.CompletedTask;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Runtime pipeline test double (used by non-sourcegen runtime tests)
+    // -------------------------------------------------------------------------
+    public sealed class CommandPipeline : ICommandPipeline<TestCommand, TestContext>
+    {
+        private readonly CallTracker _tracker;
+
+        public CommandPipeline(CallTracker tracker) => _tracker = tracker;
+
+        public ValueTask ExecuteAsync(
+            TestCommand command,
+            TestContext ctx,
+            ICommandHandler<TestCommand, TestContext> handler,
+            CancellationToken ct = default)
+        {
+            _tracker.PipelineCalled = true;
+            return new ValueTask(handler.HandleAsync(command, ctx, ct));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Open-generic middlewares (SourceGen expects open generic types)
+    // -------------------------------------------------------------------------
     internal sealed class GlobalLogMiddleware<TCommand, TContext> : ICommandMiddleware<TCommand, TContext>
         where TCommand : ICommand
     {
@@ -70,6 +131,21 @@ namespace TinyDispatcher.UnitTests
             ((TestContext)(object)ctx).Log.Add("mw:global:before");
             await runtime.NextAsync(command, ctx, ct);
             ((TestContext)(object)ctx).Log.Add("mw:global:after");
+        }
+    }
+
+    internal sealed class PolicyLogMiddleware<TCommand, TContext> : ICommandMiddleware<TCommand, TContext>
+        where TCommand : ICommand
+    {
+        public async ValueTask InvokeAsync(
+            TCommand command,
+            TContext ctx,
+            ICommandPipelineRuntime<TCommand, TContext> runtime,
+            CancellationToken ct)
+        {
+            ((TestContext)(object)ctx).Log.Add("mw:policy:before");
+            await runtime.NextAsync(command, ctx, ct);
+            ((TestContext)(object)ctx).Log.Add("mw:policy:after");
         }
     }
 
@@ -86,104 +162,5 @@ namespace TinyDispatcher.UnitTests
             await runtime.NextAsync(command, ctx, ct);
             ((TestContext)(object)ctx).Log.Add("mw:percmd:after");
         }
-    }
-    public sealed class TestContextFactory : IContextFactory<TestContext>
-    {
-        public ValueTask<TestContext> CreateAsync(CancellationToken ct = default)
-            => new(new TestContext());
-    }
-
-    public sealed class TestHandler : ICommandHandler<TestCommand, TestContext>
-    {
-        private readonly CallTracker _tracker;
-
-        public TestHandler(CallTracker tracker) => _tracker = tracker;
-
-        public Task HandleAsync(TestCommand command, TestContext ctx, CancellationToken ct = default)
-        {
-            _tracker.HandlerCalled = true;
-            ctx.Log.Add("handler:TestCommand");
-            return Task.CompletedTask;
-        }
-    }
-
-    public sealed class CommandPipeline : ICommandPipeline<TestCommand, TestContext>
-    {
-        private readonly CallTracker _tracker;
-
-        public CommandPipeline(CallTracker tracker) => _tracker = tracker;
-
-        public ValueTask ExecuteAsync(
-            TestCommand command,
-            TestContext ctx,
-            ICommandHandler<TestCommand, TestContext> handler,
-            CancellationToken ct = default)
-        {
-            _tracker.CommandPipelineCalled = true;
-            return new ValueTask(handler.HandleAsync(command, ctx, ct));
-        }
-    }
-
-
-    public sealed class PolicyPipeline : IPolicyCommandPipeline<TestCommand, TestContext>
-    {
-        private readonly CallTracker _tracker;
-
-        public PolicyPipeline(CallTracker tracker) => _tracker = tracker;
-
-        public ValueTask ExecuteAsync(
-            TestCommand command,
-            TestContext ctx,
-            ICommandHandler<TestCommand, TestContext> handler,
-            CancellationToken ct = default)
-        {
-            _tracker.PolicyPipelineCalled = true;
-            return new ValueTask(handler.HandleAsync(command, ctx, ct));
-        }
-    }
-
-
-    public sealed class GlobalPipeline : IGlobalCommandPipeline<TestCommand, TestContext>
-    {
-        private readonly CallTracker _tracker;
-
-        public GlobalPipeline(CallTracker tracker) => _tracker = tracker;
-
-        public ValueTask ExecuteAsync(
-            TestCommand command,
-            TestContext ctx,
-            ICommandHandler<TestCommand, TestContext> handler,
-            CancellationToken ct = default)
-        {
-            _tracker.GlobalPipelineCalled = true;
-            return new ValueTask(handler.HandleAsync(command, ctx, ct));
-        }
-    }
-
-
-    internal sealed class PolicyLogMiddleware<TCommand, TContext> : ICommandMiddleware<TCommand, TContext>
-    where TCommand : ICommand
-    {
-        public async ValueTask InvokeAsync(
-            TCommand command,
-            TContext ctx,
-            ICommandPipelineRuntime<TCommand, TContext> runtime,
-            CancellationToken ct)
-        {
-            ((TestContext)(object)ctx).Log.Add("mw:policy:before");
-            await runtime.NextAsync(command, ctx, ct);
-            ((TestContext)(object)ctx).Log.Add("mw:policy:after");
-        }
-    }
-
-
-    // -----------------------------------------------------------------------------
-    // Policy declaration (attributes read by SourceGen)
-    // -----------------------------------------------------------------------------
-    [TinyPolicy]
-    [UseMiddleware(typeof(PolicyLogMiddleware<,>))]
-    [ForCommand(typeof(TestCommand))]
-    internal sealed class CheckoutPolicy
-    {
     }
 }


### PR DESCRIPTION
refactor(core): move pipeline precedence from runtime to compile-time

- Unified pipeline contract under ICommandPipeline<TCommand,TContext>
- Removed policy/global pipeline interfaces
- Dispatcher simplified to single pipeline resolution
- Precedence now generator-driven
- Cleaner runtime model, fewer allocations, less branching
