### PR TITLE
refactor(pipeline): inline runtime and remove wrapper allocation

### DIFF
--- a/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelineSourceWriterGoldenSnapshotTests.cs
+++ b/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelineSourceWriterGoldenSnapshotTests.cs
@@ -23,40 +23,45 @@ public sealed class PipelineSourceWriterGoldenSnapshotTests
         var snapshot = Create_snapshot(source);
 
         var expected = string.Join(
-            "\n",
-            new[]
-            {
-                "internal sealed class TinyDispatcherGlobalPipeline<TCommand> : global::TinyDispatcher.ICommandPipeline<TCommand, global::MyApp.AppContext>",
-                "where TCommand : global::TinyDispatcher.ICommand",
-                "public TinyDispatcherGlobalPipeline(",
-                "case 0: return _globalLog.InvokeAsync(command, ctxValue, _runtime, ct);",
-                "default: return new ValueTask(_handler!.HandleAsync(command, ctxValue, ct));",
+        "\n",
+        new[]
+        {
+            // Global
+            "internal sealed class TinyDispatcherGlobalPipeline<TCommand> : global::TinyDispatcher.ICommandPipeline<TCommand, global::MyApp.AppContext>, global::TinyDispatcher.Pipeline.ICommandPipelineRuntime<TCommand, global::MyApp.AppContext>",
+            "where TCommand : global::TinyDispatcher.ICommand",
+            "public TinyDispatcherGlobalPipeline(",
+            "case 0: return _globalLog.InvokeAsync(command, ctxValue, this, ct);",
+            "default: return new ValueTask(_handler!.HandleAsync(command, ctxValue, ct));",
 
-                "internal sealed class TinyDispatcherPolicyPipeline_MyApp_CheckoutPolicy<TCommand> : global::TinyDispatcher.ICommandPipeline<TCommand, global::MyApp.AppContext>",
-                "where TCommand : global::TinyDispatcher.ICommand",
-                "public TinyDispatcherPolicyPipeline_MyApp_CheckoutPolicy(",
-                "case 0: return _globalLog.InvokeAsync(command, ctxValue, _runtime, ct);",
-                "case 1: return _policyLog.InvokeAsync(command, ctxValue, _runtime, ct);",
-                "default: return new ValueTask(_handler!.HandleAsync(command, ctxValue, ct));",
+            // Policy
+            "internal sealed class TinyDispatcherPolicyPipeline_MyApp_CheckoutPolicy<TCommand> : global::TinyDispatcher.ICommandPipeline<TCommand, global::MyApp.AppContext>, global::TinyDispatcher.Pipeline.ICommandPipelineRuntime<TCommand, global::MyApp.AppContext>",
+            "where TCommand : global::TinyDispatcher.ICommand",
+            "public TinyDispatcherPolicyPipeline_MyApp_CheckoutPolicy(",
+            "case 0: return _globalLog.InvokeAsync(command, ctxValue, this, ct);",
+            "case 1: return _policyLog.InvokeAsync(command, ctxValue, this, ct);",
+            "default: return new ValueTask(_handler!.HandleAsync(command, ctxValue, ct));",
 
-                "internal sealed class TinyDispatcherPipeline_CmdA : global::TinyDispatcher.ICommandPipeline<global::MyApp.CmdA, global::MyApp.AppContext>",
-                "public TinyDispatcherPipeline_CmdA(",
-                "case 0: return _globalLog.InvokeAsync(command, ctxValue, _runtime, ct);",
-                "case 1: return _policyLog.InvokeAsync(command, ctxValue, _runtime, ct);",
-                "case 2: return _perCommandLog.InvokeAsync(command, ctxValue, _runtime, ct);",
-                "default: return new ValueTask(_handler!.HandleAsync(command, ctxValue, ct));",
+            // Per-command
+            "internal sealed class TinyDispatcherPipeline_CmdA : global::TinyDispatcher.ICommandPipeline<global::MyApp.CmdA, global::MyApp.AppContext>, global::TinyDispatcher.Pipeline.ICommandPipelineRuntime<global::MyApp.CmdA, global::MyApp.AppContext>",
+            "public TinyDispatcherPipeline_CmdA(",
+            "case 0: return _globalLog.InvokeAsync(command, ctxValue, this, ct);",
+            "case 1: return _policyLog.InvokeAsync(command, ctxValue, this, ct);",
+            "case 2: return _perCommandLog.InvokeAsync(command, ctxValue, this, ct);",
+            "default: return new ValueTask(_handler!.HandleAsync(command, ctxValue, ct));",
 
-                "services.TryAddTransient(typeof(global::MyApp.GlobalLogMiddleware<,>));",
-                "services.TryAddTransient(typeof(global::MyApp.PerCommandLogMiddleware<,>));",
-                "services.TryAddTransient(typeof(global::MyApp.PolicyLogMiddleware<,>));",
+            // Registrations unchanged
+            "services.TryAddTransient(typeof(global::MyApp.GlobalLogMiddleware<,>));",
+            "services.TryAddTransient(typeof(global::MyApp.PerCommandLogMiddleware<,>));",
+            "services.TryAddTransient(typeof(global::MyApp.PolicyLogMiddleware<,>));",
 
-                "services.AddScoped<global::TinyDispatcher.ICommandPipeline<global::MyApp.CmdA, global::MyApp.AppContext>, global::MyApp.Generated.TinyDispatcherPipeline_CmdA>();",
-                "services.AddScoped<global::TinyDispatcher.ICommandPipeline<global::MyApp.CmdB, global::MyApp.AppContext>, global::MyApp.Generated.TinyDispatcherPolicyPipeline_MyApp_CheckoutPolicy<global::MyApp.CmdB>>();",
-                "services.AddScoped<global::TinyDispatcher.ICommandPipeline<global::MyApp.CmdC, global::MyApp.AppContext>, global::MyApp.Generated.TinyDispatcherGlobalPipeline<global::MyApp.CmdC>>();",
-            });
+            "services.AddScoped<global::TinyDispatcher.ICommandPipeline<global::MyApp.CmdA, global::MyApp.AppContext>, global::MyApp.Generated.TinyDispatcherPipeline_CmdA>();",
+            "services.AddScoped<global::TinyDispatcher.ICommandPipeline<global::MyApp.CmdB, global::MyApp.AppContext>, global::MyApp.Generated.TinyDispatcherPolicyPipeline_MyApp_CheckoutPolicy<global::MyApp.CmdB>>();",
+            "services.AddScoped<global::TinyDispatcher.ICommandPipeline<global::MyApp.CmdC, global::MyApp.AppContext>, global::MyApp.Generated.TinyDispatcherGlobalPipeline<global::MyApp.CmdC>>();",
+        });
 
-        Assert.Equal(expected, snapshot);
-    }
+
+            Assert.Equal(expected, snapshot);
+        }
 
     private static PipelinePlan Create_plan()
     {

--- a/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelineSourceWriterTests.cs
+++ b/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelineSourceWriterTests.cs
@@ -37,37 +37,6 @@ public sealed class PipelineSourceWriterTests
     }
 
     [Fact]
-    public void Runtime_is_not_at_namespace_scope()
-    {
-        var plan = Create_plan(
-            globalPipeline: Create_pipeline(
-                "TinyDispatcherGlobalPipeline",
-                true,
-                "TCommand",
-                new[] { new MiddlewareRef("global::MyApp.G1", 2) }),
-            policyPipelines: new[]
-            {
-                Create_pipeline(
-                    "TinyDispatcherPolicyPipeline_X",
-                    true,
-                    "TCommand",
-                    new[] { new MiddlewareRef("global::MyApp.P1", 2) })
-            });
-
-        var source = PipelineSourceWriter.Write(plan);
-
-        // It MUST exist (nested inside pipeline types)
-        Assert.Contains("private sealed class Runtime", source, StringComparison.Ordinal);
-
-        // But it MUST NOT appear as a namespace member (column 0 or "  " indentation).
-        // Namespace members in our generated file are indented 2 spaces.
-        // Nested members are indented 4+ spaces.
-        Assert.DoesNotMatch(
-            new Regex(@"^(?:private|  private)\s+sealed\s+class\s+Runtime\b", RegexOptions.Multiline),
-            source);
-    }
-
-    [Fact]
     public void Constructor_is_not_generic_for_open_generic_pipeline()
     {
         var plan = Create_plan(


### PR DESCRIPTION
- Make generated pipelines implement ICommandPipelineRuntime directly
- Remove nested Runtime wrapper class
- Eliminate per-pipeline runtime allocation
- Pass pipeline instance (`this`) to middleware
- Add explicit interface implementation for NextAsync
- Update golden snapshot tests

Result: simpler generated code, fewer allocations, reduced indirection.