### PR TITLE
Add ContextConsistencyValidator (DISP110 / DISP111)

### DIFF
--- a/src/TinyDispatcher.SourceGen/Diagnostics/DiagnosticCatalog.cs
+++ b/src/TinyDispatcher.SourceGen/Diagnostics/DiagnosticCatalog.cs
@@ -13,9 +13,6 @@ namespace TinyDispatcher.SourceGen
 
         #region Duplicate handler diagnostics
 
-        /// <summary>
-        /// Emitted when more than one ICommandHandler&lt;T&gt; is discovered for the same command.
-        /// </summary>
         public DiagnosticDescriptor DuplicateCommand { get; } =
             BuildDescriptor(
                 id: "DISP101",
@@ -23,9 +20,6 @@ namespace TinyDispatcher.SourceGen
                 message: "Multiple ICommandHandler for '{0}' found: '{1}' and '{2}'",
                 severity: DiagnosticSeverity.Error);
 
-        /// <summary>
-        /// Emitted when more than one IQueryHandler&lt;TQuery,TResult&gt; is discovered for the same query.
-        /// </summary>
         public DiagnosticDescriptor DuplicateQuery { get; } =
             BuildDescriptor(
                 id: "DISP201",
@@ -35,10 +29,31 @@ namespace TinyDispatcher.SourceGen
 
         #endregion
 
+        #region Context diagnostics (NEW)
+
+        public DiagnosticDescriptor MultipleContextsDetected { get; } =
+            BuildDescriptor(
+                id: "DISP110",
+                title: "Multiple TinyDispatcher contexts detected",
+                message: "Only one UseTinyDispatcher<TContext> call is allowed per project. Found {0}.",
+                severity: DiagnosticSeverity.Error);
+
+        public DiagnosticDescriptor ContextTypeNotFound { get; } =
+            BuildDescriptor(
+                id: "DISP111",
+                title: "TinyDispatcher context type not found",
+                message: "No UseTinyDispatcher<TContext> call was found, but code generation requires a context type.",
+                severity: DiagnosticSeverity.Error);
+
+        #endregion
+
         #region Public API for creating diagnostics
 
         public Diagnostic Create(DiagnosticDescriptor descriptor, params object[] args) =>
             Diagnostic.Create(descriptor, Location.None, args);
+
+        public Diagnostic Create(DiagnosticDescriptor descriptor, Location location, params object[] args) =>
+            Diagnostic.Create(descriptor, location, args);
 
         public Diagnostic CreateError(string id, string title, string message) =>
             Diagnostic.Create(
@@ -46,8 +61,6 @@ namespace TinyDispatcher.SourceGen
                 Location.None);
 
         #endregion
-
-        #region Internal helpers
 
         private static DiagnosticDescriptor BuildDescriptor(
             string id,
@@ -63,7 +76,5 @@ namespace TinyDispatcher.SourceGen
                 defaultSeverity: severity,
                 isEnabledByDefault: true);
         }
-
-        #endregion
     }
 }

--- a/src/TinyDispatcher.SourceGen/Discovery/UseTinyDispatcherInvocationExtractor.cs
+++ b/src/TinyDispatcher.SourceGen/Discovery/UseTinyDispatcherInvocationExtractor.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+
+namespace TinyDispatcher.SourceGen.Discovery;
+
+internal static class UseTinyDispatcherInvocationExtractor
+{
+    public static ImmutableArray<InvocationExpressionSyntax> FindAllUseTinyDispatcherCalls(Compilation compilation)
+    {
+        var builder = ImmutableArray.CreateBuilder<InvocationExpressionSyntax>();
+
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            var root = tree.GetRoot();
+            foreach (var node in root.DescendantNodes())
+            {
+                if (node is not InvocationExpressionSyntax inv)
+                    continue;
+
+                if (!IsUseTinyDispatcherGenericCall(inv))
+                    continue;
+
+                builder.Add(inv);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static bool IsUseTinyDispatcherGenericCall(InvocationExpressionSyntax inv)
+    {
+        // services.UseTinyDispatcher<TContext>(...)
+        if (inv.Expression is MemberAccessExpressionSyntax ma)
+        {
+            if (ma.Name is GenericNameSyntax g &&
+                g.Identifier.ValueText == "UseTinyDispatcher" &&
+                g.TypeArgumentList.Arguments.Count == 1)
+                return true;
+        }
+
+        // UseTinyDispatcher<TContext>(...)  (static import / extension form)
+        if (inv.Expression is GenericNameSyntax g2)
+        {
+            if (g2.Identifier.ValueText == "UseTinyDispatcher" &&
+                g2.TypeArgumentList.Arguments.Count == 1)
+                return true;
+        }
+
+        return false;
+    }
+}
+

--- a/src/TinyDispatcher.SourceGen/Generator/Models/UseTinyDispatcherCall.cs
+++ b/src/TinyDispatcher.SourceGen/Generator/Models/UseTinyDispatcherCall.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TinyDispatcher.SourceGen.Generator.Models;
+
+/// <summary>
+/// Represents a single UseTinyDispatcher&lt;TContext&gt; invocation discovered in syntax.
+/// We resolve the context type via semantic model when validating.
+/// </summary>
+internal readonly record struct UseTinyDispatcherCall(
+    string ContextTypeFqn,
+    Location Location);

--- a/src/TinyDispatcher.SourceGen/Validation/ContextConsistencyValidator.cs
+++ b/src/TinyDispatcher.SourceGen/Validation/ContextConsistencyValidator.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using TinyDispatcher.SourceGen.Generator.Models;
+
+namespace TinyDispatcher.SourceGen.Validation;
+
+internal static class ContextConsistencyValidator
+{
+    public static ImmutableArray<Diagnostic> Validate(
+        DiagnosticsCatalog diags,
+        ImmutableArray<UseTinyDispatcherCall> calls,
+        bool contextIsRequired)
+    {
+        if (diags is null) throw new ArgumentNullException(nameof(diags));
+
+        if (calls.IsDefaultOrEmpty || calls.Length == 0)
+        {
+            if (contextIsRequired)
+                return ImmutableArray.Create(diags.Create(diags.ContextTypeNotFound));
+
+            return ImmutableArray<Diagnostic>.Empty;
+        }
+
+        // Hard rule: only one UseTinyDispatcher<TContext> call allowed
+        if (calls.Length > 1)
+        {
+            var loc = calls[1].Location ?? Location.None;
+
+            var contexts = string.Join(", ", calls.Select(c => c.ContextTypeFqn).Distinct());
+
+            return ImmutableArray.Create(
+                diags.Create(diags.MultipleContextsDetected, loc, contexts));
+        }
+
+        return ImmutableArray<Diagnostic>.Empty;
+    }
+}

--- a/tests/TinyDispatcher.UnitTests/SourceGen/ContextConsistencyDiagnosticsTests.cs
+++ b/tests/TinyDispatcher.UnitTests/SourceGen/ContextConsistencyDiagnosticsTests.cs
@@ -1,0 +1,176 @@
+﻿#nullable enable
+
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TinyDispatcher.SourceGen.Generator;
+using Xunit;
+
+namespace TinyDispatcher.UnitTest.SourceGen;
+
+public sealed class ContextConsistencyDiagnosticsTests
+{
+    [Fact]
+    public void DISP110_when_UseTinyDispatcher_is_called_twice_with_different_contexts()
+    {
+        var (_, diags) = Run(CreateCompilationAllRefs(@"
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TinyDispatcher
+{
+  public sealed class TinyBootstrapp
+  {
+    public void UsePolicy<T>() { }
+  }
+}
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+  public interface IServiceCollection { }
+
+  public static class ServiceCollectionExtensions
+  {
+    public static IServiceCollection UseTinyDispatcher<TContext>(
+      this IServiceCollection services,
+      Action<TinyDispatcher.TinyBootstrapp> tiny)
+      => services;
+  }
+}
+
+namespace ConsoleApp
+{
+  public sealed class CtxA { }
+  public sealed class CtxB { }
+
+  public static class Startup
+  {
+    public static void Configure(Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+    {
+      services.UseTinyDispatcher<CtxA>(tiny => tiny.UsePolicy<int>());
+      services.UseTinyDispatcher<CtxB>(tiny => tiny.UsePolicy<int>());
+    }
+  }
+}
+"));
+
+        Assert.Contains(diags, d => d.Id == "DISP110");
+    }
+
+    [Fact]
+    public void DISP110_when_UseTinyDispatcher_is_called_twice_with_same_context()
+    {
+        var (_, diags) = Run(CreateCompilationAllRefs(@"
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TinyDispatcher
+{
+  public sealed class TinyBootstrapp
+  {
+    public void UsePolicy<T>() { }
+  }
+}
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+  public interface IServiceCollection { }
+
+  public static class ServiceCollectionExtensions
+  {
+    public static IServiceCollection UseTinyDispatcher<TContext>(
+      this IServiceCollection services,
+      Action<TinyDispatcher.TinyBootstrapp> tiny)
+      => services;
+  }
+}
+
+namespace ConsoleApp
+{
+  public sealed class Ctx { }
+
+  public static class Startup
+  {
+    public static void Configure(Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+    {
+      services.UseTinyDispatcher<Ctx>(tiny => tiny.UsePolicy<int>());
+      services.UseTinyDispatcher<Ctx>(tiny => tiny.UsePolicy<int>());
+    }
+  }
+}
+"));
+
+        Assert.Contains(diags, d => d.Id == "DISP110");
+    }
+
+    [Fact]
+    public void No_DISP110_when_UseTinyDispatcher_is_called_once()
+    {
+        var (_, diags) = Run(CreateCompilationAllRefs(@"
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TinyDispatcher
+{
+  public sealed class TinyBootstrapp
+  {
+    public void UsePolicy<T>() { }
+  }
+}
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+  public interface IServiceCollection { }
+
+  public static class ServiceCollectionExtensions
+  {
+    public static IServiceCollection UseTinyDispatcher<TContext>(
+      this IServiceCollection services,
+      Action<TinyDispatcher.TinyBootstrapp> tiny)
+      => services;
+  }
+}
+
+namespace ConsoleApp
+{
+  public sealed class Ctx { }
+
+  public static class Startup
+  {
+    public static void Configure(Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+      => services.UseTinyDispatcher<Ctx>(tiny => tiny.UsePolicy<int>());
+  }
+}
+"));
+
+        Assert.DoesNotContain(diags, d => d.Id == "DISP110");
+    }
+
+    private static (GeneratorDriver Driver, Diagnostic[] Diagnostics) Run(CSharpCompilation compilation)
+    {
+        var generator = new Generator();
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(generator);
+
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out var diags);
+        return (driver, diags.ToArray());
+    }
+
+    private static CSharpCompilation CreateCompilationAllRefs(string source)
+    {
+        var refs =
+            AppDomain.CurrentDomain.GetAssemblies()
+                .Where(a => !a.IsDynamic && !string.IsNullOrWhiteSpace(a.Location))
+                .Select(a => MetadataReference.CreateFromFile(a.Location))
+                .ToList();
+
+        // Ensure the source generator assembly is referenced.
+        refs.Add(MetadataReference.CreateFromFile(typeof(Generator).Assembly.Location));
+
+        return CSharpCompilation.Create(
+            assemblyName: "Tests",
+            syntaxTrees: new[] { CSharpSyntaxTree.ParseText(source) },
+            references: refs,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+}

--- a/tests/TinyDispatcher.UnitTests/TestDomain.cs
+++ b/tests/TinyDispatcher.UnitTests/TestDomain.cs
@@ -1,166 +1,154 @@
-﻿// File: tests/TinyDispatcher.UnitTests/TestDomain.cs
-// CLEANED UP for single pipeline contract (ICommandPipeline<TCommand,TContext> only)
-//
-// Changes:
-// - Removed unused usings
-// - Removed PolicyPipeline / GlobalPipeline test doubles (they don't make sense with single pipeline contract)
-// - Simplified CallTracker (only what runtime tests can assert now)
-// - Kept SourceGen-related policy + middlewares (Global/Policy/PerCommand) for execution-order tests
-// - Kept handlers + context factory
-// - Kept CommandPipeline (used by runtime DI tests)
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using TinyDispatcher.Context;
 using TinyDispatcher.Pipeline;
 
-namespace TinyDispatcher.UnitTests
+namespace TinyDispatcher.UnitTests;
+
+public sealed class CallTracker
 {
-    public sealed class CallTracker
+    public bool PipelineCalled { get; set; }
+    public bool HandlerCalled { get; set; }
+}
+
+public sealed record TestCommand(string Value) : ICommand;
+public sealed record OtherCommand(string Value) : ICommand;
+public sealed record PolicyOnlyCommand(string Value) : ICommand;
+
+// -------------------------------------------------------------------------
+// Policy declarations (attributes read by SourceGen)
+// -------------------------------------------------------------------------
+
+[TinyPolicy]
+[UseMiddleware(typeof(PolicyLogMiddleware<,>))]
+[ForCommand(typeof(PolicyOnlyCommand))]
+internal sealed class PolicyOnlyPolicy { }
+
+[TinyPolicy]
+[UseMiddleware(typeof(PolicyLogMiddleware<,>))]
+[ForCommand(typeof(TestCommand))]
+internal sealed class CheckoutPolicy { }
+
+// -------------------------------------------------------------------------
+// Test context (we assert exact execution order in SourceGen tests)
+// -------------------------------------------------------------------------
+public sealed class TestContext
+{
+    public List<string> Log { get; } = new();
+    public CancellationToken SeenByFactory { get; internal set; }
+    public CancellationToken SeenByHandler { get; internal set; }
+}
+
+// -------------------------------------------------------------------------
+// Context factory
+// -------------------------------------------------------------------------
+public sealed class TestContextFactory : IContextFactory<TestContext>
+{
+    public ValueTask<TestContext> CreateAsync(CancellationToken ct = default)
+        => new(new TestContext { SeenByFactory = ct });
+}
+
+// -------------------------------------------------------------------------
+// Handlers
+// -------------------------------------------------------------------------
+internal sealed class OtherCommandHandler : ICommandHandler<OtherCommand, TestContext>
+{
+    public Task HandleAsync(OtherCommand command, TestContext ctx, CancellationToken ct = default)
     {
-        public bool PipelineCalled { get; set; }
-        public bool HandlerCalled { get; set; }
+        ctx.Log.Add("handler:OtherCommand");
+        return Task.CompletedTask;
     }
+}
 
-    public sealed record TestCommand(string Value) : ICommand;
-    public sealed record OtherCommand(string Value) : ICommand;
-    public sealed record PolicyOnlyCommand(string Value) : ICommand;
-
-    // -------------------------------------------------------------------------
-    // Policy declarations (attributes read by SourceGen)
-    // -------------------------------------------------------------------------
-
-    [TinyPolicy]
-    [UseMiddleware(typeof(PolicyLogMiddleware<,>))]
-    [ForCommand(typeof(PolicyOnlyCommand))]
-    internal sealed class PolicyOnlyPolicy { }
-
-    [TinyPolicy]
-    [UseMiddleware(typeof(PolicyLogMiddleware<,>))]
-    [ForCommand(typeof(TestCommand))]
-    internal sealed class CheckoutPolicy { }
-
-    // -------------------------------------------------------------------------
-    // Test context (we assert exact execution order in SourceGen tests)
-    // -------------------------------------------------------------------------
-    public sealed class TestContext
+internal sealed class PolicyOnlyCommandHandler : ICommandHandler<PolicyOnlyCommand, TestContext>
+{
+    public Task HandleAsync(PolicyOnlyCommand command, TestContext ctx, CancellationToken ct = default)
     {
-        public List<string> Log { get; } = new();
-        public CancellationToken SeenByFactory { get; internal set; }
-        public CancellationToken SeenByHandler { get; internal set; }
+        ctx.Log.Add("handler:PolicyOnlyCommand");
+        return Task.CompletedTask;
     }
+}
 
-    // -------------------------------------------------------------------------
-    // Context factory
-    // -------------------------------------------------------------------------
-    public sealed class TestContextFactory : IContextFactory<TestContext>
+public sealed class TestHandler : ICommandHandler<TestCommand, TestContext>
+{
+    private readonly CallTracker _tracker;
+
+    public TestHandler(CallTracker tracker) => _tracker = tracker;
+
+    public Task HandleAsync(TestCommand command, TestContext ctx, CancellationToken ct = default)
     {
-        public ValueTask<TestContext> CreateAsync(CancellationToken ct = default)
-            => new(new TestContext { SeenByFactory = ct });
+        _tracker.HandlerCalled = true;
+        ctx.SeenByHandler = ct;
+        ctx.Log.Add("handler:TestCommand");
+        return Task.CompletedTask;
     }
+}
 
-    // -------------------------------------------------------------------------
-    // Handlers
-    // -------------------------------------------------------------------------
-    internal sealed class OtherCommandHandler : ICommandHandler<OtherCommand, TestContext>
+// -------------------------------------------------------------------------
+// Runtime pipeline test double (used by non-sourcegen runtime tests)
+// -------------------------------------------------------------------------
+public sealed class CommandPipeline : ICommandPipeline<TestCommand, TestContext>
+{
+    private readonly CallTracker _tracker;
+
+    public CommandPipeline(CallTracker tracker) => _tracker = tracker;
+
+    public ValueTask ExecuteAsync(
+        TestCommand command,
+        TestContext ctx,
+        ICommandHandler<TestCommand, TestContext> handler,
+        CancellationToken ct = default)
     {
-        public Task HandleAsync(OtherCommand command, TestContext ctx, CancellationToken ct = default)
-        {
-            ctx.Log.Add("handler:OtherCommand");
-            return Task.CompletedTask;
-        }
+        _tracker.PipelineCalled = true;
+        return new ValueTask(handler.HandleAsync(command, ctx, ct));
     }
+}
 
-    internal sealed class PolicyOnlyCommandHandler : ICommandHandler<PolicyOnlyCommand, TestContext>
+// -------------------------------------------------------------------------
+// Open-generic middlewares (SourceGen expects open generic types)
+// -------------------------------------------------------------------------
+internal sealed class GlobalLogMiddleware<TCommand, TContext> : ICommandMiddleware<TCommand, TContext>
+    where TCommand : ICommand
+{
+    public async ValueTask InvokeAsync(
+        TCommand command,
+        TContext ctx,
+        ICommandPipelineRuntime<TCommand, TContext> runtime,
+        CancellationToken ct)
     {
-        public Task HandleAsync(PolicyOnlyCommand command, TestContext ctx, CancellationToken ct = default)
-        {
-            ctx.Log.Add("handler:PolicyOnlyCommand");
-            return Task.CompletedTask;
-        }
+        ((TestContext)(object)ctx).Log.Add("mw:global:before");
+        await runtime.NextAsync(command, ctx, ct);
+        ((TestContext)(object)ctx).Log.Add("mw:global:after");
     }
+}
 
-    public sealed class TestHandler : ICommandHandler<TestCommand, TestContext>
+internal sealed class PolicyLogMiddleware<TCommand, TContext> : ICommandMiddleware<TCommand, TContext>
+    where TCommand : ICommand
+{
+    public async ValueTask InvokeAsync(
+        TCommand command,
+        TContext ctx,
+        ICommandPipelineRuntime<TCommand, TContext> runtime,
+        CancellationToken ct)
     {
-        private readonly CallTracker _tracker;
-
-        public TestHandler(CallTracker tracker) => _tracker = tracker;
-
-        public Task HandleAsync(TestCommand command, TestContext ctx, CancellationToken ct = default)
-        {
-            _tracker.HandlerCalled = true;
-            ctx.SeenByHandler = ct;
-            ctx.Log.Add("handler:TestCommand");
-            return Task.CompletedTask;
-        }
+        ((TestContext)(object)ctx).Log.Add("mw:policy:before");
+        await runtime.NextAsync(command, ctx, ct);
+        ((TestContext)(object)ctx).Log.Add("mw:policy:after");
     }
+}
 
-    // -------------------------------------------------------------------------
-    // Runtime pipeline test double (used by non-sourcegen runtime tests)
-    // -------------------------------------------------------------------------
-    public sealed class CommandPipeline : ICommandPipeline<TestCommand, TestContext>
+internal sealed class PerCommandLogMiddleware<TCommand, TContext> : ICommandMiddleware<TCommand, TContext>
+    where TCommand : ICommand
+{
+    public async ValueTask InvokeAsync(
+        TCommand command,
+        TContext ctx,
+        ICommandPipelineRuntime<TCommand, TContext> runtime,
+        CancellationToken ct)
     {
-        private readonly CallTracker _tracker;
-
-        public CommandPipeline(CallTracker tracker) => _tracker = tracker;
-
-        public ValueTask ExecuteAsync(
-            TestCommand command,
-            TestContext ctx,
-            ICommandHandler<TestCommand, TestContext> handler,
-            CancellationToken ct = default)
-        {
-            _tracker.PipelineCalled = true;
-            return new ValueTask(handler.HandleAsync(command, ctx, ct));
-        }
-    }
-
-    // -------------------------------------------------------------------------
-    // Open-generic middlewares (SourceGen expects open generic types)
-    // -------------------------------------------------------------------------
-    internal sealed class GlobalLogMiddleware<TCommand, TContext> : ICommandMiddleware<TCommand, TContext>
-        where TCommand : ICommand
-    {
-        public async ValueTask InvokeAsync(
-            TCommand command,
-            TContext ctx,
-            ICommandPipelineRuntime<TCommand, TContext> runtime,
-            CancellationToken ct)
-        {
-            ((TestContext)(object)ctx).Log.Add("mw:global:before");
-            await runtime.NextAsync(command, ctx, ct);
-            ((TestContext)(object)ctx).Log.Add("mw:global:after");
-        }
-    }
-
-    internal sealed class PolicyLogMiddleware<TCommand, TContext> : ICommandMiddleware<TCommand, TContext>
-        where TCommand : ICommand
-    {
-        public async ValueTask InvokeAsync(
-            TCommand command,
-            TContext ctx,
-            ICommandPipelineRuntime<TCommand, TContext> runtime,
-            CancellationToken ct)
-        {
-            ((TestContext)(object)ctx).Log.Add("mw:policy:before");
-            await runtime.NextAsync(command, ctx, ct);
-            ((TestContext)(object)ctx).Log.Add("mw:policy:after");
-        }
-    }
-
-    internal sealed class PerCommandLogMiddleware<TCommand, TContext> : ICommandMiddleware<TCommand, TContext>
-        where TCommand : ICommand
-    {
-        public async ValueTask InvokeAsync(
-            TCommand command,
-            TContext ctx,
-            ICommandPipelineRuntime<TCommand, TContext> runtime,
-            CancellationToken ct)
-        {
-            ((TestContext)(object)ctx).Log.Add("mw:percmd:before");
-            await runtime.NextAsync(command, ctx, ct);
-            ((TestContext)(object)ctx).Log.Add("mw:percmd:after");
-        }
+        ((TestContext)(object)ctx).Log.Add("mw:percmd:before");
+        await runtime.NextAsync(command, ctx, ct);
+        ((TestContext)(object)ctx).Log.Add("mw:percmd:after");
     }
 }


### PR DESCRIPTION
- Enforce single UseTinyDispatcher<TContext> call per project
- Emit DISP110 when multiple bootstrap calls are detected
- Emit DISP111 when context is required but missing
- Resolve context types via semantic model (symbol-based)
- Stop generation on fatal context errors
- Add unit tests covering context validation scenarios