### PR TITLE
chore(samples): align all samples with latest TinyDispatcher NuGet

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning"
-                      Version="3.6.139"
                       PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,9 @@
 <Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning"
-                      PrivateAssets="All" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.139" />
   </ItemGroup>
 </Project>

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -1,0 +1,13 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.139" />
+    <PackageVersion Include="TinyDispatcher" Version="0.1.103-alpha-g6d84474285" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
+  </ItemGroup>
+</Project>

--- a/samples/src/TinyDispatcher.Samples.Aspnet/TinyDispatcher.Samples.Aspnet.csproj
+++ b/samples/src/TinyDispatcher.Samples.Aspnet/TinyDispatcher.Samples.Aspnet.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -7,8 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
-    <PackageReference Include="TinyDispatcher" Version="0.1.28-alpha-g81295fddf9" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="TinyDispatcher" />
   </ItemGroup>
 
 </Project>

--- a/samples/src/TinyDispatcher.Samples.ClosedContextMiddleware/TinyDispatcher.Samples.ClosedContextMiddleware.csproj
+++ b/samples/src/TinyDispatcher.Samples.ClosedContextMiddleware/TinyDispatcher.Samples.ClosedContextMiddleware.csproj
@@ -7,9 +7,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
-    <PackageReference Include="TinyDispatcher" Version="0.1.28-alpha-g81295fddf9" />
+   <ItemGroup>
+    <PackageReference Include="TinyDispatcher" />
+     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
-
 </Project>

--- a/samples/src/TinyDispatcher.Samples.CustomContext/CustomCallbackContext.cs
+++ b/samples/src/TinyDispatcher.Samples.CustomContext/CustomCallbackContext.cs
@@ -5,8 +5,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using TinyDispatcher;
 using TinyDispatcher.Dispatching;
+using TinyDispatcher.Pipeline;
 
 namespace TinyDispatcher.Samples.CustomContext;
+
 public sealed class CustomContextCallbackFeature
 {
     public static async Task RunAsync(CancellationToken ct = default)
@@ -75,14 +77,14 @@ public sealed class CustomContextCallbackFeature
     public sealed class ConsoleLoggingMiddleware<TCommand, TContext> : ICommandMiddleware<TCommand, TContext>
         where TCommand : ICommand
     {
-        public async Task InvokeAsync(
+        public async ValueTask InvokeAsync(
             TCommand command,
             TContext ctx,
-            CommandDelegate<TCommand, TContext> next,
-            CancellationToken ct)
+            ICommandPipelineRuntime<TCommand, TContext> runtime,
+            CancellationToken ct = default)
         {
             Console.WriteLine($"[MW] -> {typeof(TCommand).Name}");
-            await next(command, ctx, ct);
+            await runtime.NextAsync(command, ctx, ct).ConfigureAwait(false);
             Console.WriteLine($"[MW] <- {typeof(TCommand).Name}");
         }
     }

--- a/samples/src/TinyDispatcher.Samples.CustomContext/TinyDispatcher.Samples.CustomContext.csproj
+++ b/samples/src/TinyDispatcher.Samples.CustomContext/TinyDispatcher.Samples.CustomContext.csproj
@@ -8,8 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
-    <PackageReference Include="TinyDispatcher" Version="0.1.28-alpha-g81295fddf9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
-
-</Project>
+  <ItemGroup>
+    <PackageReference Include="TinyDispatcher" />
+  </ItemGroup>
+ </Project>

--- a/samples/src/TinyDispatcher.Samples.CustomContextFactory/CustomContextFactory.cs
+++ b/samples/src/TinyDispatcher.Samples.CustomContextFactory/CustomContextFactory.cs
@@ -6,8 +6,10 @@ using System.Threading.Tasks;
 using TinyDispatcher;
 using TinyDispatcher.Context;
 using TinyDispatcher.Dispatching;
+using TinyDispatcher.Pipeline;
 
 namespace TinyDispatcher.Samples.CustomContextFactory;
+
 public sealed class CustomContextFactoryFeature
 {
     public static async Task RunAsync(CancellationToken ct = default)
@@ -89,14 +91,14 @@ public sealed class CustomContextFactoryFeature
         : ICommandMiddleware<TCommand, TContext>
         where TCommand : ICommand
     {
-        public async Task InvokeAsync(
+        public async ValueTask InvokeAsync(
             TCommand command,
             TContext ctx,
-            CommandDelegate<TCommand, TContext> next,
-            CancellationToken ct)
+            ICommandPipelineRuntime<TCommand, TContext> runtime,
+            CancellationToken ct = default)
         {
             Console.WriteLine($"[MW] -> {typeof(TCommand).Name}");
-            await next(command, ctx, ct);
+            await runtime.NextAsync(command, ctx, ct).ConfigureAwait(false);
             Console.WriteLine($"[MW] <- {typeof(TCommand).Name}");
         }
     }

--- a/samples/src/TinyDispatcher.Samples.CustomContextFactory/TinyDispatcher.Samples.CustomContextFactory.csproj
+++ b/samples/src/TinyDispatcher.Samples.CustomContextFactory/TinyDispatcher.Samples.CustomContextFactory.csproj
@@ -8,8 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
-    <PackageReference Include="TinyDispatcher" Version="0.1.28-alpha-g81295fddf9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="TinyDispatcher" />
+  </ItemGroup>
 </Project>

--- a/samples/src/TinyDispatcher.Samples.Pipelines/TinyBootstrap.cs
+++ b/samples/src/TinyDispatcher.Samples.Pipelines/TinyBootstrap.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using TinyDispatcher.Dispatching;
+
+namespace TinyDispatcher.Samples.Pipelines;
+
+public static class TinyBootstrap
+{
+    public static IServiceCollection AddTiny(this IServiceCollection services)
+    {
+        services.UseTinyDispatcher<AppContext>(tiny =>
+        {
+            // Global middleware available in this project
+            tiny.UseGlobalMiddleware(typeof(GlobalMiddlewareSample.GlobalLoggingMiddleware<,>));
+
+            // Per-command middleware mapping
+            tiny.UseMiddlewareFor<PerCommandMiddlewareSample.Pay>(typeof(PerCommandMiddlewareSample.OnlyForPayMiddleware<,>));
+
+            // Policy (commands + middleware)
+            tiny.UsePolicy<PolicySample.CheckoutPolicy>();
+        });
+
+        // Register middleware types used anywhere
+        services.AddTransient(typeof(GlobalMiddlewareSample.GlobalLoggingMiddleware<,>));
+        services.AddTransient(typeof(PerCommandMiddlewareSample.OnlyForPayMiddleware<,>));
+        services.AddTransient(typeof(PolicySample.PolicyLoggingMiddleware<,>));
+        services.AddTransient(typeof(PolicySample.PolicyValidationMiddleware<,>));
+
+        return services;
+    }
+}

--- a/samples/src/TinyDispatcher.Samples.Pipelines/TinyDispatcher.Samples.Pipelines.csproj
+++ b/samples/src/TinyDispatcher.Samples.Pipelines/TinyDispatcher.Samples.Pipelines.csproj
@@ -10,10 +10,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
-    <PackageReference Include="TinyDispatcher" Version="0.1.28-alpha-g81295fddf9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
-
-
+  <ItemGroup>
+    <PackageReference Include="TinyDispatcher" />
+  </ItemGroup>
 </Project>

--- a/samples/src/TinyDispatcher.Samples.ShippedContext/TinyDispatcher.Samples.ShippedContext.csproj
+++ b/samples/src/TinyDispatcher.Samples.ShippedContext/TinyDispatcher.Samples.ShippedContext.csproj
@@ -8,8 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
-    <PackageReference Include="TinyDispatcher" Version="0.1.28-alpha-g81295fddf9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="TinyDispatcher" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
- Updated samples to consume latest published TinyDispatcher prerelease
- Migrated all middleware to runtime-based signature (ICommandPipelineRuntime)
- Removed legacy CommandDelegate usage
- Ensured single UseTinyDispatcher<TContext> per project
- Validated generator, diagnostics and pipeline behavior via NuGet consumption
- Confirmed all samples compile and execute successfully

This verifies end-to-end correctness of the published package and prevents "works via project reference only" regressions.