### PR TITLE
refactor(generator): restructure Analyze pipeline and method ordering…

### DIFF
--- a/src/TinyDispatcher.SourceGen/Generator/Models/MiddlewareRef.cs
+++ b/src/TinyDispatcher.SourceGen/Generator/Models/MiddlewareRef.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using Microsoft.CodeAnalysis;
+using System.Collections.Immutable;
 
 namespace TinyDispatcher.SourceGen.Generator.Models;
 
@@ -14,4 +15,10 @@ namespace TinyDispatcher.SourceGen.Generator.Models;
 public readonly record struct MiddlewareRef(
     INamedTypeSymbol OpenTypeSymbol,
     string OpenTypeFqn,
-    int Arity);
+    int Arity)
+{
+    internal static ImmutableArray<MiddlewareRef> FromOrderedEntries(ImmutableArray<OrderedEntry> globals)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
… for readability

- Refactored `Analyze` into a clear orchestration flow
- Extracted logical phases:
  - option resolution
  - handler discovery
  - pipeline extraction
  - validation context construction
- Introduced `PipelineFacts` as a local aggregation record
- Normalized method ordering so the class reads top-to-bottom (callers appear before callees)
- No behavioral changes
- All tests green

The Generator now reads as a linear book:
Initialize → Execute → Analyze → Validate → Emit.