### PR TITLE
refactor(generator): split orchestration into analyzer and validator …

### DIFF
--- a/src/TinyDispatcher.SourceGen/Generator/Generator.cs
+++ b/src/TinyDispatcher.SourceGen/Generator/Generator.cs
@@ -1,33 +1,11 @@
-﻿// TinyDispatcher.SourceGen/Generator.cs
-// -----------------------------------------------------------------------------
-// TinyDispatcher incremental source generator (netstandard2.0 friendly)
-//
-// ALWAYS emits:
-//  - DispatcherModuleInitializer
-//  - ThisAssemblyContribution
-//  - EmptyPipelineContribution
-//
-// Conditionally emits (HOST ARTIFACTS):
-//  - TinyDispatcherPipeline.g.cs       (when middleware/policies are declared via TinyBootstrap)
-//
-// HOST GATE (NO HEURISTICS, NO MSBUILD FLAGS):
-//  - Only emit host artifacts if we find at least one call to:
-//      services.UseTinyDispatcher<TContext>(tiny => { ... })
-//    Discovery is SYNTAX-based.
-// -----------------------------------------------------------------------------
-
-#nullable enable
+﻿#nullable enable
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using TinyDispatcher.SourceGen.Abstractions;
-using TinyDispatcher.SourceGen.Discovery;
-using TinyDispatcher.SourceGen.Emitters;
 using TinyDispatcher.SourceGen.Emitters.Handlers;
 using TinyDispatcher.SourceGen.Emitters.ModuleInitializer;
 using TinyDispatcher.SourceGen.Emitters.Pipelines;
@@ -37,23 +15,13 @@ using TinyDispatcher.SourceGen.Validation;
 
 namespace TinyDispatcher.SourceGen.Generator;
 
-// ============================================================================
-// Generator
-// ============================================================================
-
 [Generator]
 public sealed class Generator : IIncrementalGenerator
 {
-    // =====================================================================
-    // Entry point
-    // =====================================================================
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var syntax = new UseTinyDispatcherSyntax();
 
-        // ---------------------------------------------------------------------
-        // Handler candidates (anchor – always produces)
-        // ---------------------------------------------------------------------
         var handlerCandidates =
             context.SyntaxProvider
                 .CreateSyntaxProvider(
@@ -66,10 +34,6 @@ public sealed class Generator : IIncrementalGenerator
                     })
                 .Collect();
 
-        // ---------------------------------------------------------------------
-        // Find UseTinyDispatcher<TContext>(...) calls (SYNTAX-based)
-        // IMPORTANT: do not rely on GetSymbolInfo here.
-        // ---------------------------------------------------------------------
         var useTinyCalls =
             context.SyntaxProvider
                 .CreateSyntaxProvider(
@@ -90,9 +54,6 @@ public sealed class Generator : IIncrementalGenerator
         context.RegisterSourceOutput(pipeline, Execute);
     }
 
-    // =====================================================================
-    // EXECUTE
-    // =====================================================================
     private static void Execute(
         SourceProductionContext spc,
         (((Compilation Compilation,
@@ -108,14 +69,14 @@ public sealed class Generator : IIncrementalGenerator
         var roslyn = new RoslynGeneratorContext(spc);
         var diagnosticsCatalog = new DiagnosticsCatalog();
 
-        var analysis = Analyze(
+        var analysis = GeneratorAnalyzer.Analyze(
             compilation,
             handlerSymbols,
             useTinyCallsSyntax,
             data.Options,
             diagnosticsCatalog);
 
-        var bag = Validate(analysis.ValidationContext);
+        var bag = GeneratorValidator.Validate(analysis.ValidationContext);
 
         if (ReportAndHasErrors(roslyn, bag))
             return;
@@ -155,205 +116,6 @@ public sealed class Generator : IIncrementalGenerator
         return bag.HasErrors;
     }
 
-    // =====================================================================
-    // ANALYZE (facts-only)
-    // =====================================================================
-    private static GeneratorAnalysis Analyze(
-        Compilation compilation,
-        ImmutableArray<INamedTypeSymbol> handlerSymbols,
-        ImmutableArray<InvocationExpressionSyntax> useTinyCallsSyntax,
-        AnalyzerConfigOptionsProvider optionsProvider,
-        DiagnosticsCatalog diagnosticsCatalog)
-    {
-        GuardInputs(compilation, diagnosticsCatalog);
-
-        // Components (facts-only)
-        var invocationExtractor = new TinyBootstrapInvocationExtractor();
-        var policyBuilder = new PolicySpecBuilder();
-        var ordering = new MiddlewareOrdering();
-        var ctxInference = new ContextInference();
-        var optionsFactory = new GeneratorOptionsFactory(new OptionsProvider());
-
-        var effectiveOptions = ResolveEffectiveOptions(
-            compilation,
-            optionsProvider,
-            useTinyCallsSyntax,
-            ctxInference,
-            optionsFactory);
-
-        var expectedContextFqn = GetExpectedContextFqn(effectiveOptions);
-
-        var discoveryResult = DiscoverHandlers(
-            compilation,
-            handlerSymbols,
-            effectiveOptions);
-
-        var pipelineFacts = ExtractPipelineFacts(
-            compilation,
-            useTinyCallsSyntax,
-            invocationExtractor,
-            ctxInference,
-            policyBuilder,
-            ordering);
-
-        var validationContext = BuildValidationContext(
-            compilation,
-            discoveryResult,
-            diagnosticsCatalog,
-            useTinyCallsSyntax,
-            expectedContextFqn,
-            pipelineFacts);
-
-        return new GeneratorAnalysis(
-            Compilation: compilation,
-            UseTinyCallsSyntax: useTinyCallsSyntax,
-            Discovery: discoveryResult,
-            EffectiveOptions: effectiveOptions,
-            ValidationContext: validationContext,
-            Globals: pipelineFacts.Globals,
-            PerCommand: pipelineFacts.PerCommand,
-            Policies: pipelineFacts.Policies);
-    }
-
-    private static void GuardInputs(
-        Compilation compilation,
-        DiagnosticsCatalog diagnosticsCatalog)
-    {
-        if (compilation is null)
-            throw new ArgumentNullException(nameof(compilation));
-
-        if (diagnosticsCatalog is null)
-            throw new ArgumentNullException(nameof(diagnosticsCatalog));
-    }
-
-    private static GeneratorOptions ResolveEffectiveOptions(
-        Compilation compilation,
-        AnalyzerConfigOptionsProvider optionsProvider,
-        ImmutableArray<InvocationExpressionSyntax> useTinyCallsSyntax,
-        ContextInference ctxInference,
-        GeneratorOptionsFactory optionsFactory)
-    {
-        var baseOptions = optionsFactory.Create(compilation, optionsProvider);
-
-        var inferredCtxFqn =
-            ctxInference.TryInferContextTypeFromUseTinyCalls(useTinyCallsSyntax, compilation);
-
-        return optionsFactory.ApplyInferredContextIfMissing(baseOptions, inferredCtxFqn);
-    }
-
-    private static string GetExpectedContextFqn(GeneratorOptions options)
-    {
-        if (string.IsNullOrWhiteSpace(options.CommandContextType))
-            return string.Empty;
-
-        return Fqn.EnsureGlobal(options.CommandContextType!);
-    }
-
-    private static DiscoveryResult DiscoverHandlers(
-        Compilation compilation,
-        ImmutableArray<INamedTypeSymbol> handlerSymbols,
-        GeneratorOptions effectiveOptions)
-    {
-        var handlerDiscovery = new RoslynHandlerDiscovery(
-            Known.CoreNamespace,
-            includeNamespacePrefix: effectiveOptions.IncludeNamespacePrefix,
-            commandContextTypeFqn: effectiveOptions.CommandContextType);
-
-        return handlerDiscovery.Discover(compilation, handlerSymbols);
-    }
-
-    private static PipelineFacts ExtractPipelineFacts(
-        Compilation compilation,
-        ImmutableArray<InvocationExpressionSyntax> useTinyCallsSyntax,
-        TinyBootstrapInvocationExtractor invocationExtractor,
-        ContextInference ctxInference,
-        PolicySpecBuilder policyBuilder,
-        MiddlewareOrdering ordering)
-    {
-        var useTinyDispatcherInvocations =
-            UseTinyDispatcherInvocationExtractor.FindAllUseTinyDispatcherCalls(compilation);
-
-        var allUseTinyDispatcherCalls =
-            ctxInference.ResolveAllUseTinyDispatcherContexts(useTinyDispatcherInvocations, compilation);
-
-        // Temp collections for extractor
-        var globalEntries = new List<OrderedEntry>();
-        var perCmdEntries = new List<OrderedPerCommandEntry>();
-        var policyTypeSymbols = new List<INamedTypeSymbol>();
-
-        for (var i = 0; i < useTinyCallsSyntax.Length; i++)
-        {
-            invocationExtractor.Extract(
-                useTinyCallsSyntax[i],
-                compilation,
-                globalEntries,
-                perCmdEntries,
-                policyTypeSymbols);
-        }
-
-        var globals = ordering.OrderAndDistinctGlobals(globalEntries);
-        var perCommand = ordering.BuildPerCommandMap(perCmdEntries);
-        var policies = policyBuilder.Build(compilation, policyTypeSymbols);
-
-        return new PipelineFacts(
-            globals,
-            perCommand,
-            policies,
-            allUseTinyDispatcherCalls);
-    }
-
-    private static GeneratorValidationContext BuildValidationContext(
-        Compilation compilation,
-        DiscoveryResult discoveryResult,
-        DiagnosticsCatalog diagnosticsCatalog,
-        ImmutableArray<InvocationExpressionSyntax> useTinyCallsSyntax,
-        string expectedContextFqn,
-        PipelineFacts pipelineFacts)
-    {
-        return new GeneratorValidationContext.Builder(
-                compilation,
-                discoveryResult,
-                diagnosticsCatalog)
-            .WithHostGate(useTinyCallsSyntax, isHost: useTinyCallsSyntax.Length > 0)
-            .WithUseTinyDispatcherCalls(pipelineFacts.AllUseTinyCalls)
-            .WithExpectedContext(expectedContextFqn)
-            .WithPipelineConfig(
-                pipelineFacts.Globals,
-                pipelineFacts.PerCommand,
-                pipelineFacts.Policies)
-            .Build();
-    }
-
-    private sealed record PipelineFacts(
-        ImmutableArray<MiddlewareRef> Globals,
-        ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> PerCommand,
-        ImmutableDictionary<string, PolicySpec> Policies,
-        ImmutableArray<UseTinyDispatcherCall> AllUseTinyCalls);
-
-    // =====================================================================
-    // VALIDATE
-    // =====================================================================
-    private static readonly ContextConsistencyValidator _contextConsistency = new();
-    private static readonly DuplicateHandlerValidator _duplicateHandler = new();
-    private static readonly MiddlewareRefShapeValidator _middlewareRefShape = new();
-    private static readonly PipelineDiagnosticsValidator _pipelineDiagnostics = new();
-    private static readonly MissingHandlerValidator _missingHandler = new();
-    private static DiagnosticBag Validate(GeneratorValidationContext vctx)
-    {
-        var bag = new DiagnosticBag();
-
-        _contextConsistency.Validate(vctx, bag);
-        _duplicateHandler.Validate(vctx, bag);
-        _missingHandler.Validate(vctx, bag);
-        _middlewareRefShape.Validate(vctx, bag);
-        _pipelineDiagnostics.Validate(vctx, bag);
-
-        return bag;
-    }
-
-    // =====================================================================
-    // EMIT
-    // =====================================================================
     private static GeneratorOptions BuildEmitOptions(GeneratorAnalysis analysis)
     {
         var vctx = analysis.ValidationContext;

--- a/src/TinyDispatcher.SourceGen/Generator/GeneratorAnalyzer.cs
+++ b/src/TinyDispatcher.SourceGen/Generator/GeneratorAnalyzer.cs
@@ -1,0 +1,189 @@
+﻿#nullable enable
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using TinyDispatcher.SourceGen.Discovery;
+using TinyDispatcher.SourceGen.Generator.Models;
+using TinyDispatcher.SourceGen.Internal;
+using TinyDispatcher.SourceGen.Validation;
+
+namespace TinyDispatcher.SourceGen.Generator;
+
+internal static class GeneratorAnalyzer
+{
+    public static GeneratorAnalysis Analyze(
+        Compilation compilation,
+        ImmutableArray<INamedTypeSymbol> handlerSymbols,
+        ImmutableArray<InvocationExpressionSyntax> useTinyCallsSyntax,
+        AnalyzerConfigOptionsProvider optionsProvider,
+        DiagnosticsCatalog diagnosticsCatalog)
+    {
+        GuardInputs(compilation, diagnosticsCatalog);
+
+        // Components (facts-only)
+        var invocationExtractor = new TinyBootstrapInvocationExtractor();
+        var policyBuilder = new PolicySpecBuilder();
+        var ordering = new MiddlewareOrdering();
+        var ctxInference = new ContextInference();
+        var optionsFactory = new GeneratorOptionsFactory(new OptionsProvider());
+
+        var effectiveOptions = ResolveEffectiveOptions(
+            compilation,
+            optionsProvider,
+            useTinyCallsSyntax,
+            ctxInference,
+            optionsFactory);
+
+        var expectedContextFqn = GetExpectedContextFqn(effectiveOptions);
+
+        var discoveryResult = DiscoverHandlers(
+            compilation,
+            handlerSymbols,
+            effectiveOptions);
+
+        var pipelineFacts = ExtractPipelineFacts(
+            compilation,
+            useTinyCallsSyntax,
+            invocationExtractor,
+            ctxInference,
+            policyBuilder,
+            ordering);
+
+        var validationContext = BuildValidationContext(
+            compilation,
+            discoveryResult,
+            diagnosticsCatalog,
+            useTinyCallsSyntax,
+            expectedContextFqn,
+            pipelineFacts);
+
+        return new GeneratorAnalysis(
+            Compilation: compilation,
+            UseTinyCallsSyntax: useTinyCallsSyntax,
+            Discovery: discoveryResult,
+            EffectiveOptions: effectiveOptions,
+            ValidationContext: validationContext,
+            Globals: pipelineFacts.Globals,
+            PerCommand: pipelineFacts.PerCommand,
+            Policies: pipelineFacts.Policies);
+    }
+
+    private static void GuardInputs(
+        Compilation compilation,
+        DiagnosticsCatalog diagnosticsCatalog)
+    {
+        if (compilation is null)
+            throw new ArgumentNullException(nameof(compilation));
+
+        if (diagnosticsCatalog is null)
+            throw new ArgumentNullException(nameof(diagnosticsCatalog));
+    }
+
+    private static GeneratorOptions ResolveEffectiveOptions(
+        Compilation compilation,
+        AnalyzerConfigOptionsProvider optionsProvider,
+        ImmutableArray<InvocationExpressionSyntax> useTinyCallsSyntax,
+        ContextInference ctxInference,
+        GeneratorOptionsFactory optionsFactory)
+    {
+        var baseOptions = optionsFactory.Create(compilation, optionsProvider);
+
+        var inferredCtxFqn =
+            ctxInference.TryInferContextTypeFromUseTinyCalls(useTinyCallsSyntax, compilation);
+
+        return optionsFactory.ApplyInferredContextIfMissing(baseOptions, inferredCtxFqn);
+    }
+
+    private static string GetExpectedContextFqn(GeneratorOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.CommandContextType))
+            return string.Empty;
+
+        return Fqn.EnsureGlobal(options.CommandContextType!);
+    }
+
+    private static DiscoveryResult DiscoverHandlers(
+        Compilation compilation,
+        ImmutableArray<INamedTypeSymbol> handlerSymbols,
+        GeneratorOptions effectiveOptions)
+    {
+        var handlerDiscovery = new RoslynHandlerDiscovery(
+            Known.CoreNamespace,
+            includeNamespacePrefix: effectiveOptions.IncludeNamespacePrefix,
+            commandContextTypeFqn: effectiveOptions.CommandContextType);
+
+        return handlerDiscovery.Discover(compilation, handlerSymbols);
+    }
+
+    private static PipelineFacts ExtractPipelineFacts(
+        Compilation compilation,
+        ImmutableArray<InvocationExpressionSyntax> useTinyCallsSyntax,
+        TinyBootstrapInvocationExtractor invocationExtractor,
+        ContextInference ctxInference,
+        PolicySpecBuilder policyBuilder,
+        MiddlewareOrdering ordering)
+    {
+        var useTinyDispatcherInvocations =
+            UseTinyDispatcherInvocationExtractor.FindAllUseTinyDispatcherCalls(compilation);
+
+        var allUseTinyDispatcherCalls =
+            ctxInference.ResolveAllUseTinyDispatcherContexts(useTinyDispatcherInvocations, compilation);
+
+        // Temp collections for extractor
+        var globalEntries = new List<OrderedEntry>();
+        var perCmdEntries = new List<OrderedPerCommandEntry>();
+        var policyTypeSymbols = new List<INamedTypeSymbol>();
+
+        for (var i = 0; i < useTinyCallsSyntax.Length; i++)
+        {
+            invocationExtractor.Extract(
+                useTinyCallsSyntax[i],
+                compilation,
+                globalEntries,
+                perCmdEntries,
+                policyTypeSymbols);
+        }
+
+        var globals = ordering.OrderAndDistinctGlobals(globalEntries);
+        var perCommand = ordering.BuildPerCommandMap(perCmdEntries);
+        var policies = policyBuilder.Build(compilation, policyTypeSymbols);
+
+        return new PipelineFacts(
+            globals,
+            perCommand,
+            policies,
+            allUseTinyDispatcherCalls);
+    }
+
+    private static GeneratorValidationContext BuildValidationContext(
+        Compilation compilation,
+        DiscoveryResult discoveryResult,
+        DiagnosticsCatalog diagnosticsCatalog,
+        ImmutableArray<InvocationExpressionSyntax> useTinyCallsSyntax,
+        string expectedContextFqn,
+        PipelineFacts pipelineFacts)
+    {
+        return new GeneratorValidationContext.Builder(
+                compilation,
+                discoveryResult,
+                diagnosticsCatalog)
+            .WithHostGate(useTinyCallsSyntax, isHost: useTinyCallsSyntax.Length > 0)
+            .WithUseTinyDispatcherCalls(pipelineFacts.AllUseTinyCalls)
+            .WithExpectedContext(expectedContextFqn)
+            .WithPipelineConfig(
+                pipelineFacts.Globals,
+                pipelineFacts.PerCommand,
+                pipelineFacts.Policies)
+            .Build();
+    }
+
+    private sealed record PipelineFacts(
+        ImmutableArray<MiddlewareRef> Globals,
+        ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> PerCommand,
+        ImmutableDictionary<string, PolicySpec> Policies,
+        ImmutableArray<UseTinyDispatcherCall> AllUseTinyCalls);
+}

--- a/src/TinyDispatcher.SourceGen/Generator/GeneratorValidator.cs
+++ b/src/TinyDispatcher.SourceGen/Generator/GeneratorValidator.cs
@@ -1,0 +1,27 @@
+﻿#nullable enable
+
+using TinyDispatcher.SourceGen.Validation;
+
+namespace TinyDispatcher.SourceGen.Generator;
+
+internal static class GeneratorValidator
+{
+    private static readonly ContextConsistencyValidator _contextConsistency = new();
+    private static readonly DuplicateHandlerValidator _duplicateHandler = new();
+    private static readonly MissingHandlerValidator _missingHandler = new();
+    private static readonly MiddlewareRefShapeValidator _middlewareRefShape = new();
+    private static readonly PipelineDiagnosticsValidator _pipelineDiagnostics = new();
+
+    public static DiagnosticBag Validate(GeneratorValidationContext vctx)
+    {
+        var bag = new DiagnosticBag();
+
+        _contextConsistency.Validate(vctx, bag);
+        _duplicateHandler.Validate(vctx, bag);
+        _missingHandler.Validate(vctx, bag);
+        _middlewareRefShape.Validate(vctx, bag);
+        _pipelineDiagnostics.Validate(vctx, bag);
+
+        return bag;
+    }
+}

--- a/src/TinyDispatcher/TinyDispatcher.csproj
+++ b/src/TinyDispatcher/TinyDispatcher.csproj
@@ -67,7 +67,17 @@
       - Minor allocation reductions
       - Improved determinism and readability
 
-      This release continues the stabilization path toward v1.0.
+      Next steps toward v1.0:
+
+      We are entering a focused file-by-file polishing phase.
+      The goal is to review every component for clarity, consistency,
+      diagnostic quality, and long-term maintainability.
+
+      No major features are planned before v1.0.
+      The focus is stability, readability, and API confidence.
+
+      v1.0 will be released once the generator reaches
+      a level of simplicity and determinism we are fully satisfied with.
     </PackageReleaseNotes>
 
 


### PR DESCRIPTION
…components

- Extracted GeneratorAnalyzer (facts-only analysis pipeline)
- Extracted GeneratorValidator (validation chain + cached validators)
- Simplified Generator to orchestration-only responsibilities
- Improved cohesion and separation of concerns
- No behavioral changes
- All tests remain green

This prepares the generator for final file-by-file polishing ahead of v1.0 stabilization.