### PR TITLE
perf: optimize NoOpContext factory to remove scoped delegate allocation

### DIFF
--- a/src/TinyDispatcher/Context/NoOpContextFactory.cs
+++ b/src/TinyDispatcher/Context/NoOpContextFactory.cs
@@ -1,0 +1,11 @@
+﻿using TinyDispatcher.Context;
+
+internal sealed class NoOpContextFactory : IContextFactory<NoOpContext>
+{
+    public static readonly NoOpContextFactory Instance = new();
+
+    private NoOpContextFactory() { }
+
+    public ValueTask<NoOpContext> CreateAsync(CancellationToken ct = default)
+        => new(default(NoOpContext));
+}

--- a/src/TinyDispatcher/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/TinyDispatcher/DependencyInjection/ServiceCollectionExtensions.cs
@@ -68,11 +68,19 @@ public static class ServiceCollectionExtensions
     /// Internally reuses the standard bootstrap path with a static no-op context factory.
     /// </summary>
     public static IServiceCollection UseTinyNoOpContext(
-        this IServiceCollection services,
-        Action<TinyBootstrap> configure)
-        => services.UseTinyDispatcher<NoOpContext>(
-            configure,
-            static (_, __) => new ValueTask<NoOpContext>(default(NoOpContext)));
+     this IServiceCollection services,
+     Action<TinyBootstrap> configure)
+    {
+        configure?.Invoke(new TinyBootstrap(services));
+
+        services.TryAddSingleton<IContextFactory<NoOpContext>>(NoOpContextFactory.Instance);
+
+        services.AddDispatcher<NoOpContext>(contextFactory: null);
+
+        DispatcherPipelineBootstrap.Apply(services);
+
+        return services;
+    }
 
     private static void EnsureContextFactoryRegistered<TContext>(IServiceCollection services)
     {


### PR DESCRIPTION
Replaces the delegate-based IContextFactory<NoOpContext> registration with a dedicated singleton factory.

This avoids per-scope DelegateContextFactory allocation and reduces indirection during dispatch while keeping the handler signature unchanged.

No public API changes.