### PR TITLE
fix(pipeline): make generated pipelines re-entrant and thread-safe

### DIFF
--- a/tests/TinyDispatcher.UnitTests/ConcurrentDispatchSameCommandTypeTests.cs
+++ b/tests/TinyDispatcher.UnitTests/ConcurrentDispatchSameCommandTypeTests.cs
@@ -1,0 +1,162 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using TinyDispatcher.Context;
+using TinyDispatcher.Dispatching;
+using TinyDispatcher.Pipeline;
+using Xunit;
+
+namespace TinyDispatcher.UnitTests;
+
+public sealed class ConcurrentDispatchSameCommandTypeTests
+{
+    public sealed record Ping(int Id) : ICommand;
+
+    [Fact]
+    public async Task Concurrent_dispatch_same_command_type_within_same_scope_is_thread_safe()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Register handler
+        services.AddTransient<ICommandHandler<Ping, TestContext>, PingHandler>();
+
+        // Register probe state as singleton so both concurrent calls share the same recorder (for assertions)
+        services.AddSingleton<ProbeState>();
+        services.AddScoped<IContextFactory<TestContext>, TestContextFactory>();
+        services.AddTransient<ICommandHandler<TestCommand, TestContext>, TestHandler>();
+        TinyDispatcher.Generated.ThisAssemblyPipelineContribution.Add(services);
+
+        // Dispatcher
+        services.AddScoped<IDispatcher<TestContext>>(sp =>
+            new Dispatcher<TestContext>(sp, sp.GetRequiredService<IContextFactory<TestContext>>()));
+
+        var sp = services.BuildServiceProvider(validateScopes: true);
+
+        // Create ONE scope (simulating a single request scope)
+        using var scope = sp.CreateScope();
+
+        var dispatcher = scope.ServiceProvider.GetRequiredService<IDispatcher<TestContext>>();
+        var state = scope.ServiceProvider.GetRequiredService<ProbeState>();
+
+        // Act: run TWO concurrent dispatches of the SAME command type in the SAME scope
+        var t1 = dispatcher.DispatchAsync(new Ping(1));
+        var t2 = dispatcher.DispatchAsync(new Ping(2));
+
+        await Task.WhenAll(t1, t2);
+
+        // Assert:
+        // Each command must have observed the full pipeline (M0 -> M1 -> Handler) exactly once.
+        // And the order must be correct per command id.
+        Assert.True(state.TryGetTrace(1, out var trace1), "Missing trace for command 1.");
+        Assert.True(state.TryGetTrace(2, out var trace2), "Missing trace for command 2.");
+
+        Assert.Equal("M0-Pre,M1-Pre,Handler,M1-Post,M0-Post", trace1);
+        Assert.Equal("M0-Pre,M1-Pre,Handler,M1-Post,M0-Post", trace2);
+
+        // Also ensure handler count is exactly 2
+        Assert.Equal(2, state.HandlerHits);
+    }
+
+    /// <summary>
+    /// Shared recorder across the two concurrent executions.
+    /// Stores per-command ordered events.
+    /// </summary>
+    public sealed class ProbeState
+    {
+        private readonly ConcurrentDictionary<int, ConcurrentQueue<string>> _events = new();
+        private int _handlerHits;
+
+        public int HandlerHits => Volatile.Read(ref _handlerHits);
+
+        public void Record(int id, string evt)
+        {
+            var q = _events.GetOrAdd(id, _ => new ConcurrentQueue<string>());
+            q.Enqueue(evt);
+        }
+
+        public void HitHandler() => Interlocked.Increment(ref _handlerHits);
+
+        public bool TryGetTrace(int id, out string trace)
+        {
+            trace = string.Empty;
+
+            if (!_events.TryGetValue(id, out var q))
+                return false;
+
+            trace = string.Join(",", q.ToArray());
+            return true;
+        }
+    }
+
+    public sealed class PingHandler : ICommandHandler<Ping, TestContext>
+    {
+        private readonly ProbeState _state;
+
+        public PingHandler(ProbeState state) => _state = state;
+
+        public Task HandleAsync(Ping command, TestContext context, CancellationToken cancellationToken = default)
+        {
+            _state.Record(command.Id, "Handler");
+            _state.HitHandler();
+            return Task.CompletedTask;
+        }
+    }
+
+    // Middleware 0: forces an async boundary to increase likelihood of interleaving
+    public sealed class ProbeMiddleware0<TCommand, TContext> : ICommandMiddleware<TCommand, TContext>
+        where TCommand : ICommand
+    {
+        private readonly ProbeState _state;
+
+        public ProbeMiddleware0(ProbeState state) => _state = state;
+
+        public async ValueTask InvokeAsync(
+            TCommand command,
+            TContext context,
+            ICommandPipelineRuntime<TCommand, TContext> runtime,
+            CancellationToken ct)
+        {
+            if (command is Ping p)
+                _state.Record(p.Id, "M0-Pre");
+
+            // Force interleaving
+            await Task.Yield();
+
+            await runtime.NextAsync(command, context, ct).ConfigureAwait(false);
+
+            if (command is Ping p2)
+                _state.Record(p2.Id, "M0-Post");
+        }
+    }
+
+    // Middleware 1: forces another async boundary
+    public sealed class ProbeMiddleware1<TCommand, TContext> : ICommandMiddleware<TCommand, TContext>
+        where TCommand : ICommand
+    {
+        private readonly ProbeState _state;
+
+        public ProbeMiddleware1(ProbeState state) => _state = state;
+
+        public async ValueTask InvokeAsync(
+            TCommand command,
+            TContext context,
+            ICommandPipelineRuntime<TCommand, TContext> runtime,
+            CancellationToken ct)
+        {
+            if (command is Ping p)
+                _state.Record(p.Id, "M1-Pre");
+
+            await Task.Yield();
+
+            await runtime.NextAsync(command, context, ct).ConfigureAwait(false);
+
+            if (command is Ping p2)
+                _state.Record(p2.Id, "M1-Post");
+        }
+    }
+}

--- a/tests/TinyDispatcher.UnitTests/GeneratedPipelinesHostGate.cs
+++ b/tests/TinyDispatcher.UnitTests/GeneratedPipelinesHostGate.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using static TinyDispatcher.UnitTests.ConcurrentDispatchSameCommandTypeTests;
 
 namespace TinyDispatcher.UnitTests
 {
@@ -20,7 +21,11 @@ namespace TinyDispatcher.UnitTests
             services.UseTinyDispatcher<TestContext>(tiny =>
             {
                 tiny.UseGlobalMiddleware(typeof(GlobalLogMiddleware<,>));
+                tiny.UseGlobalMiddleware(typeof(ProbeMiddleware0<,>));
+                tiny.UseGlobalMiddleware(typeof(ProbeMiddleware1<,>));
+                
                 tiny.UseMiddlewareFor<TestCommand>(typeof(PerCommandLogMiddleware<,>));
+                
                 tiny.UsePolicy<CheckoutPolicy>();
                 tiny.UsePolicy<PolicyOnlyPolicy>();
             });

--- a/tests/TinyDispatcher.UnitTests/PipelineResolutionTests.cs
+++ b/tests/TinyDispatcher.UnitTests/PipelineResolutionTests.cs
@@ -8,6 +8,7 @@ using TinyDispatcher.Dispatching;
 using TinyDispatcher.Pipeline;
 using TinyDispatcher.UnitTests;
 using Xunit;
+using static TinyDispatcher.UnitTests.ConcurrentDispatchSameCommandTypeTests;
 using static TinyDispatcher.UnitTets.PipelineSelectionTests;
 
 namespace TinyDispatcher.UnitTets;
@@ -28,6 +29,7 @@ public sealed class PipelineResolutionTest
         var services = new ServiceCollection();
 
         // Middleware implementations used by the generated pipelines
+        services.AddSingleton<ProbeState>();
         services.AddScoped(typeof(GlobalLogMiddleware<,>));
         services.AddScoped(typeof(PerCommandLogMiddleware<,>));
         services.AddScoped(typeof(PolicyLogMiddleware<,>));

--- a/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelineSourceWriterGoldenSnapshotTests.cs
+++ b/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelineSourceWriterGoldenSnapshotTests.cs
@@ -27,41 +27,38 @@ public sealed class PipelineSourceWriterGoldenSnapshotTests
         var snapshot = Create_snapshot(source);
 
         var expected = string.Join(
-            "\n",
-            new[]
-            {
-                // Global
-                "internal sealed class TinyDispatcherGlobalPipeline<TCommand> : global::TinyDispatcher.ICommandPipeline<TCommand, global::MyApp.AppContext>, global::TinyDispatcher.Pipeline.ICommandPipelineRuntime<TCommand, global::MyApp.AppContext>",
-                "where TCommand : global::TinyDispatcher.ICommand",
-                "public TinyDispatcherGlobalPipeline(",
-                "case 0: return _globalLog.InvokeAsync(command, ctxValue, this, ct);",
-                "default: return new ValueTask(_handler!.HandleAsync(command, ctxValue, ct));",
+     "\n",
+     new[]
+     {
+        // Global
+        "internal sealed class TinyDispatcherGlobalPipeline<TCommand> : global::TinyDispatcher.ICommandPipeline<TCommand, global::MyApp.AppContext>",
+        "where TCommand : global::TinyDispatcher.ICommand",
+        "case 0: return _pipeline._globalLog.InvokeAsync(command, ctxValue, this, ct);",
+        "default: return new ValueTask(_handler.HandleAsync(command, ctxValue, ct));",
 
-                // Policy
-                "internal sealed class TinyDispatcherPolicyPipeline_MyApp_CheckoutPolicy<TCommand> : global::TinyDispatcher.ICommandPipeline<TCommand, global::MyApp.AppContext>, global::TinyDispatcher.Pipeline.ICommandPipelineRuntime<TCommand, global::MyApp.AppContext>",
-                "where TCommand : global::TinyDispatcher.ICommand",
-                "public TinyDispatcherPolicyPipeline_MyApp_CheckoutPolicy(",
-                "case 0: return _globalLog.InvokeAsync(command, ctxValue, this, ct);",
-                "case 1: return _policyLog.InvokeAsync(command, ctxValue, this, ct);",
-                "default: return new ValueTask(_handler!.HandleAsync(command, ctxValue, ct));",
+        // Policy
+        "internal sealed class TinyDispatcherPolicyPipeline_MyApp_CheckoutPolicy<TCommand> : global::TinyDispatcher.ICommandPipeline<TCommand, global::MyApp.AppContext>",
+        "where TCommand : global::TinyDispatcher.ICommand",
+        "case 0: return _pipeline._globalLog.InvokeAsync(command, ctxValue, this, ct);",
+        "case 1: return _pipeline._policyLog.InvokeAsync(command, ctxValue, this, ct);",
+        "default: return new ValueTask(_handler.HandleAsync(command, ctxValue, ct));",
 
-                // Per-command
-                "internal sealed class TinyDispatcherPipeline_CmdA : global::TinyDispatcher.ICommandPipeline<global::MyApp.CmdA, global::MyApp.AppContext>, global::TinyDispatcher.Pipeline.ICommandPipelineRuntime<global::MyApp.CmdA, global::MyApp.AppContext>",
-                "public TinyDispatcherPipeline_CmdA(",
-                "case 0: return _globalLog.InvokeAsync(command, ctxValue, this, ct);",
-                "case 1: return _policyLog.InvokeAsync(command, ctxValue, this, ct);",
-                "case 2: return _perCommandLog.InvokeAsync(command, ctxValue, this, ct);",
-                "default: return new ValueTask(_handler!.HandleAsync(command, ctxValue, ct));",
+        // Per-command
+        "internal sealed class TinyDispatcherPipeline_CmdA : global::TinyDispatcher.ICommandPipeline<global::MyApp.CmdA, global::MyApp.AppContext>",
+        "case 0: return _pipeline._globalLog.InvokeAsync(command, ctxValue, this, ct);",
+        "case 1: return _pipeline._policyLog.InvokeAsync(command, ctxValue, this, ct);",
+        "case 2: return _pipeline._perCommandLog.InvokeAsync(command, ctxValue, this, ct);",
+        "default: return new ValueTask(_handler.HandleAsync(command, ctxValue, ct));",
 
-                // Registrations unchanged
-                "services.TryAddTransient(typeof(global::MyApp.GlobalLogMiddleware<,>));",
-                "services.TryAddTransient(typeof(global::MyApp.PerCommandLogMiddleware<,>));",
-                "services.TryAddTransient(typeof(global::MyApp.PolicyLogMiddleware<,>));",
+        // Registrations unchanged
+        "services.TryAddTransient(typeof(global::MyApp.GlobalLogMiddleware<,>));",
+        "services.TryAddTransient(typeof(global::MyApp.PerCommandLogMiddleware<,>));",
+        "services.TryAddTransient(typeof(global::MyApp.PolicyLogMiddleware<,>));",
 
-                "services.AddScoped<global::TinyDispatcher.ICommandPipeline<global::MyApp.CmdA, global::MyApp.AppContext>, global::MyApp.Generated.TinyDispatcherPipeline_CmdA>();",
-                "services.AddScoped<global::TinyDispatcher.ICommandPipeline<global::MyApp.CmdB, global::MyApp.AppContext>, global::MyApp.Generated.TinyDispatcherPolicyPipeline_MyApp_CheckoutPolicy<global::MyApp.CmdB>>();",
-                "services.AddScoped<global::TinyDispatcher.ICommandPipeline<global::MyApp.CmdC, global::MyApp.AppContext>, global::MyApp.Generated.TinyDispatcherGlobalPipeline<global::MyApp.CmdC>>();",
-            });
+        "services.AddScoped<global::TinyDispatcher.ICommandPipeline<global::MyApp.CmdA, global::MyApp.AppContext>, global::MyApp.Generated.TinyDispatcherPipeline_CmdA>();",
+        "services.AddScoped<global::TinyDispatcher.ICommandPipeline<global::MyApp.CmdB, global::MyApp.AppContext>, global::MyApp.Generated.TinyDispatcherPolicyPipeline_MyApp_CheckoutPolicy<global::MyApp.CmdB>>();",
+        "services.AddScoped<global::TinyDispatcher.ICommandPipeline<global::MyApp.CmdC, global::MyApp.AppContext>, global::MyApp.Generated.TinyDispatcherGlobalPipeline<global::MyApp.CmdC>>();",
+     });
 
         Assert.Equal(expected, snapshot);
     }
@@ -138,10 +135,7 @@ public sealed class PipelineSourceWriterGoldenSnapshotTests
 
     private static string Create_snapshot(string source)
     {
-        // Normalize CRLF and take only "structural" lines.
-        // This gives us a stable "golden" without being sensitive to whitespace/indent tweaks.
         var normalized = source.Replace("\r\n", "\n", StringComparison.Ordinal);
-
         var lines = normalized.Split('\n');
 
         var keep = new List<string>(256);
@@ -153,7 +147,6 @@ public sealed class PipelineSourceWriterGoldenSnapshotTests
 
             if (t.StartsWith("internal sealed class ", StringComparison.Ordinal) ||
                 t.StartsWith("where TCommand : ", StringComparison.Ordinal) ||
-                t.StartsWith("public TinyDispatcher", StringComparison.Ordinal) ||
                 t.StartsWith("case ", StringComparison.Ordinal) ||
                 t.StartsWith("default: ", StringComparison.Ordinal) ||
                 t.StartsWith("services.", StringComparison.Ordinal))


### PR DESCRIPTION
Move mutable execution state (_index, _handler) from the scoped pipeline instance to a per-dispatch Runtime object.

This guarantees correct concurrent dispatch behavior within the same DI scope while preserving middleware reuse and overall performance characteristics.

No public API changes.