### PR TITLE
Refactor DI bootstrap helpers and fix Dispatcher validations

### DIFF
--- a/src/TinyDispatcher/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/TinyDispatcher/DependencyInjection/ServiceCollectionExtensions.cs
@@ -48,18 +48,8 @@ public static class ServiceCollectionExtensions
         // User config (middleware, policies, etc.)
         configure?.Invoke(new TinyBootstrap(services));
 
-        if (contextFactory is null && typeof(TContext) == typeof(AppContext))
-        {
-            services.TryAddScoped<IContextFactory<TContext>>(sp =>
-                (IContextFactory<TContext>)(object)
-                new DefaultAppContextFactory(sp.GetServices<IFeatureInitializer>()));
-        }
-
-        // Core registration
-        services.AddDispatcher<TContext>(contextFactory);
-
-        // Apply generated pipeline registrations contributed by module initializers
-        DispatcherPipelineBootstrap.Apply(services);
+        RegisterDefaultAppContextFactoryWhenNeeded(services, contextFactory);
+        RegisterDispatcherAndApplyPipelineBootstrap(services, contextFactory);
 
         return services;
     }
@@ -69,18 +59,40 @@ public static class ServiceCollectionExtensions
     /// Internally reuses the standard bootstrap path with a static no-op context factory.
     /// </summary>
     public static IServiceCollection UseTinyNoOpContext(
-     this IServiceCollection services,
-     Action<TinyBootstrap> configure)
+        this IServiceCollection services,
+        Action<TinyBootstrap> configure)
     {
         configure?.Invoke(new TinyBootstrap(services));
-
-        services.TryAddSingleton<IContextFactory<NoOpContext>>(NoOpContextFactory.Instance);
-
-        services.AddDispatcher<NoOpContext>(contextFactory: null);
-
-        DispatcherPipelineBootstrap.Apply(services);
+        RegisterNoOpContextFactory(services);
+        RegisterDispatcherAndApplyPipelineBootstrap<NoOpContext>(services);
 
         return services;
+    }
+
+    private static void RegisterDefaultAppContextFactoryWhenNeeded<TContext>(
+        IServiceCollection services,
+        Func<IServiceProvider, CancellationToken, ValueTask<TContext>>? contextFactory)
+    {
+        if (contextFactory is not null || typeof(TContext) != typeof(AppContext))
+            return;
+
+        services.TryAddScoped<IContextFactory<TContext>>(sp =>
+            (IContextFactory<TContext>)(object)
+            new DefaultAppContextFactory(sp.GetServices<IFeatureInitializer>()));
+    }
+
+    private static void RegisterNoOpContextFactory(IServiceCollection services)
+        => services.TryAddSingleton<IContextFactory<NoOpContext>>(NoOpContextFactory.Instance);
+
+    private static void RegisterDispatcherAndApplyPipelineBootstrap<TContext>(
+        IServiceCollection services,
+        Func<IServiceProvider, CancellationToken, ValueTask<TContext>>? contextFactory = null)
+    {
+        // Core registration
+        services.AddDispatcher(contextFactory);
+
+        // Apply generated pipeline registrations contributed by module initializers
+        DispatcherPipelineBootstrap.Apply(services);
     }
 
     private static void EnsureContextFactoryRegistered<TContext>(IServiceCollection services)

--- a/src/TinyDispatcher/Dispatching/Dispatcher.cs
+++ b/src/TinyDispatcher/Dispatching/Dispatcher.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,7 +22,7 @@ public sealed class Dispatcher<TContext> : IDispatcher<TContext>
     public Dispatcher(IServiceProvider services, IContextFactory<TContext> contextFactory)
     {
         _services = services ?? throw new ArgumentNullException(nameof(services));
-        _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(_contextFactory));
+        _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
     }
 
     public async Task DispatchAsync<TCommand>(TCommand command, CancellationToken ct = default)
@@ -53,11 +52,6 @@ public sealed class Dispatcher<TContext> : IDispatcher<TContext>
         if (query is null) throw new ArgumentNullException(nameof(query));
 
         var handler = _services.GetRequiredService<IQueryHandler<TQuery, TResult>>();
-        if (handler == null)
-        {
-            throw new InvalidOperationException(
-                $"No handler registered for query '{typeof(TQuery).FullName}'.");
-        }
         return handler.HandleAsync(query, ct);
     }
 }


### PR DESCRIPTION
### Motivation

- Improve clarity and reuse in DI bootstrapping by extracting registration logic for default `AppContext`, `NoOpContext`, and dispatcher + pipeline bootstrap into dedicated helpers. 
- Remove duplicated registration code paths and centralize `Dispatcher` registration behavior. 
- Fix minor runtime issues in `Dispatcher<TContext>` including an incorrect `ArgumentNullException` parameter name and unnecessary null-check for query handlers.

### Description

- Extracted `RegisterDefaultAppContextFactoryWhenNeeded`, `RegisterNoOpContextFactory`, and `RegisterDispatcherAndApplyPipelineBootstrap` helper methods in `ServiceCollectionExtensions` and replaced inline registration logic in `UseTinyDispatcher` and `UseTinyNoOpContext` with these helpers. 
- `UseTinyNoOpContext` now invokes `RegisterNoOpContextFactory` and `RegisterDispatcherAndApplyPipelineBootstrap<NoOpContext>` and returns the service collection consistently. 
- Fixed `Dispatcher<TContext>` by removing an unused `using`, correcting the `ArgumentNullException` to use `nameof(contextFactory)`, and removing an unnecessary null-check for query handler resolution since `GetRequiredService` already throws when a handler is missing. 

### Testing

- Ran the project unit test suite with `dotnet test` and the tests completed successfully. 
- Verified that DI registrations for `AppContext` and `NoOpContext` follow the previous semantics via existing tests. 
- Validated that `Dispatcher` behavior for command and query dispatch paths remains covered by automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df2ab06b048326a7d19d154697774a)