### PR TITLE
Refactor source generator emission planning

### DIFF
--- a/src/TinyDispatcher.SourceGen/Emitters/EmptyPipelineContributionEmitter.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/EmptyPipelineContributionEmitter.cs
@@ -5,9 +5,9 @@ using TinyDispatcher.SourceGen.Generator.Models;
 
 namespace TinyDispatcher.SourceGen;
 
-internal sealed class EmptyPipelineContributionEmitter : ICodeEmitter
+internal sealed class EmptyPipelineContributionEmitter
 {
-    public void Emit(IGeneratorContext context, DiscoveryResult result, GeneratorOptions options)
+    public void Emit(IGeneratorContext context, GeneratorOptions options)
     {
         var ns = options.GeneratedNamespace;
 

--- a/src/TinyDispatcher.SourceGen/Emitters/Handlers/HandlerRegistrationsEmitter.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Handlers/HandlerRegistrationsEmitter.cs
@@ -1,16 +1,13 @@
 ﻿using Microsoft.CodeAnalysis.Text;
 using System.Text;
 using TinyDispatcher.SourceGen.Abstractions;
-using TinyDispatcher.SourceGen.Generator.Models;
 
 namespace TinyDispatcher.SourceGen.Emitters.Handlers;
 
-internal sealed class HandlerRegistrationsEmitter : ICodeEmitter
+internal sealed class HandlerRegistrationsEmitter
 {
-    public void Emit(IGeneratorContext context, DiscoveryResult result, GeneratorOptions options)
+    public void Emit(IGeneratorContext context, HandlerRegistrationsPlan plan)
     {
-        var plan = HandlerRegistrationsPlanner.Build(result, options);
-
         var sourceWriter = new HandlerRegistrationsSourceWriter();
         var source = sourceWriter.Write(plan);
 

--- a/src/TinyDispatcher.SourceGen/Emitters/ModuleInitializer/ModuleInitializerEmitter.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/ModuleInitializer/ModuleInitializerEmitter.cs
@@ -3,24 +3,13 @@
 using System.Text;
 using Microsoft.CodeAnalysis.Text;
 using TinyDispatcher.SourceGen.Abstractions;
-using TinyDispatcher.SourceGen.Generator.Models;
 
 namespace TinyDispatcher.SourceGen.Emitters.ModuleInitializer;
 
-internal sealed class ModuleInitializerEmitter : ICodeEmitter
+internal sealed class ModuleInitializerEmitter
 {
-    public void Emit(IGeneratorContext context, DiscoveryResult result, GeneratorOptions options)
+    public void Emit(IGeneratorContext context, ModuleInitializerPlan plan)
     {
-        Emit(context, result, options, hasPipelineContributions: false);
-    }
-
-    public void Emit(
-        IGeneratorContext context,
-        DiscoveryResult result,
-        GeneratorOptions options,
-        bool hasPipelineContributions)
-    {
-        var plan = ModuleInitializerPlanner.Build(result, options, hasPipelineContributions);
         if (!plan.ShouldEmit)
             return;
 

--- a/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsEmitter.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsEmitter.cs
@@ -7,7 +7,7 @@ using TinyDispatcher.SourceGen.Generator.Models;
 
 namespace TinyDispatcher.SourceGen.Emitters.PipelineMaps;
 
-internal sealed class PipelineMapsEmitter : ICodeEmitter
+internal sealed class PipelineMapsEmitter
 {
     private readonly ImmutableArray<MiddlewareRef> _globals;
     private readonly ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> _perCommand;

--- a/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsInspector.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsInspector.cs
@@ -147,7 +147,7 @@ internal sealed class PipelineMapInspector
     {
         var map = new Dictionary<string, PolicyContribution>(StringComparer.Ordinal);
 
-        var orderedPolicies = PipelinePolicyOrdering.GetPoliciesInStableOrder(policies);
+        var orderedPolicies = PipelineOrdering.GetPoliciesInStableOrder(policies);
         for (var i = 0; i < orderedPolicies.Length; i++)
         {
             var p = orderedPolicies[i];

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineEmitter.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineEmitter.cs
@@ -1,50 +1,15 @@
 ﻿#nullable enable
 
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using System.Text;
 using TinyDispatcher.SourceGen.Abstractions;
-using TinyDispatcher.SourceGen.Generator;
-using TinyDispatcher.SourceGen.Generator.Models;
 
 namespace TinyDispatcher.SourceGen.Emitters.Pipelines;
 
-internal sealed class PipelineEmitter : ICodeEmitter
+internal sealed class PipelineEmitter
 {
-    private readonly ImmutableArray<MiddlewareRef> _globalMiddlewares;
-    private readonly ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> _perCommand;
-    private readonly ImmutableDictionary<string, PolicySpec> _policies;
-
-    public PipelineEmitter(
-        ImmutableArray<MiddlewareRef> globalMiddlewares,
-        ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> perCommand,
-        ImmutableDictionary<string, PolicySpec> policies)
+    public void Emit(IGeneratorContext context, PipelinePlan plan)
     {
-        _globalMiddlewares = globalMiddlewares;
-        _perCommand = perCommand ?? ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>.Empty;
-        _policies = policies ?? ImmutableDictionary<string, PolicySpec>.Empty;
-    }
-
-    public void Emit(IGeneratorContext context, DiscoveryResult result, GeneratorOptions options)
-    {
-        if (options is null) return;
-        if (string.IsNullOrWhiteSpace(options.CommandContextType)) return;
-
-        var hasAny =
-            (!_globalMiddlewares.IsDefaultOrEmpty && _globalMiddlewares.Length > 0) ||
-            (_perCommand.Count > 0) ||
-            (_policies.Count > 0);
-
-        if (!hasAny) return;
-
-        var plan = PipelinePlanner.Build(_globalMiddlewares, _perCommand, _policies, result, options);
-        if (!plan.ShouldEmit) return;
-
         var source = PipelineSourceWriter.Write(plan);
 
         context.AddSource(

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineOrdering.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineOrdering.cs
@@ -5,8 +5,21 @@ using TinyDispatcher.SourceGen.Generator.Models;
 
 namespace TinyDispatcher.SourceGen.Emitters.Pipelines;
 
-internal static class PipelinePolicyOrdering
+internal static class PipelineOrdering
 {
+    public static string[] GetStringsInStableOrder(IEnumerable<string> values)
+    {
+        var ordered = new List<string>();
+        foreach (var value in values)
+        {
+            ordered.Add(value);
+        }
+
+        ordered.Sort(StringComparer.Ordinal);
+
+        return CopyStringsToArray(ordered);
+    }
+
     public static PolicySpec[] GetPoliciesInStableOrder(ImmutableDictionary<string, PolicySpec> policies)
     {
         if (policies.Count == 0)
@@ -31,6 +44,18 @@ internal static class PipelinePolicyOrdering
         var rightPolicyName = PipelineTypeNames.NormalizeFqn(right.PolicyTypeFqn);
 
         return string.Compare(leftPolicyName, rightPolicyName, StringComparison.Ordinal);
+    }
+
+    private static string[] CopyStringsToArray(List<string> values)
+    {
+        var result = new string[values.Count];
+
+        for (var i = 0; i < values.Count; i++)
+        {
+            result[i] = values[i];
+        }
+
+        return result;
     }
 
     private static PolicySpec[] CopyPoliciesToArray(List<PolicySpec> policies)

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePlanner.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePlanner.cs
@@ -151,7 +151,7 @@ internal static class PipelinePlanner
 
         var list = new List<PipelineDefinition>(policies.Count);
 
-        var orderedPolicies = PipelinePolicyOrdering.GetPoliciesInStableOrder(policies);
+        var orderedPolicies = PipelineOrdering.GetPoliciesInStableOrder(policies);
         for (var i = 0; i < orderedPolicies.Length; i++)
         {
             var p = orderedPolicies[i];
@@ -185,7 +185,7 @@ internal static class PipelinePlanner
 
         var list = new List<PipelineDefinition>(perCmd.Count);
 
-        var orderedCommands = GetKeysInStableOrder(perCmd.Keys);
+        var orderedCommands = PipelineOrdering.GetStringsInStableOrder(perCmd.Keys);
         for (var i = 0; i < orderedCommands.Length; i++)
         {
             var cmdFqn = orderedCommands[i];
@@ -233,7 +233,7 @@ internal static class PipelinePlanner
     {
         var map = new Dictionary<string, MiddlewareRef[]>(StringComparer.Ordinal);
 
-        var orderedPolicies = PipelinePolicyOrdering.GetPoliciesInStableOrder(policies);
+        var orderedPolicies = PipelineOrdering.GetPoliciesInStableOrder(policies);
         for (var i = 0; i < orderedPolicies.Length; i++)
         {
             var p = orderedPolicies[i];
@@ -307,27 +307,4 @@ internal static class PipelinePlanner
         return regs.ToImmutableArray();
     }
 
-    private static string[] GetKeysInStableOrder(IEnumerable<string> keys)
-    {
-        var ordered = new List<string>();
-        foreach (var key in keys)
-        {
-            ordered.Add(key);
-        }
-
-        ordered.Sort(StringComparer.Ordinal);
-        return CopyStringsToArray(ordered);
-    }
-
-    private static string[] CopyStringsToArray(List<string> values)
-    {
-        var result = new string[values.Count];
-
-        for (var i = 0; i < values.Count; i++)
-        {
-            result[i] = values[i];
-        }
-
-        return result;
-    }
 }

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineRegistrationPlanner.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineRegistrationPlanner.cs
@@ -33,7 +33,7 @@ internal static class PipelineRegistrationPlanner
         ImmutableDictionary<string, PolicySpec> policies)
     {
         var map = new Dictionary<string, string>(StringComparer.Ordinal);
-        var orderedPolicies = PipelinePolicyOrdering.GetPoliciesInStableOrder(policies);
+        var orderedPolicies = PipelineOrdering.GetPoliciesInStableOrder(policies);
 
         for (var i = 0; i < orderedPolicies.Length; i++)
         {
@@ -87,7 +87,7 @@ internal static class PipelineRegistrationPlanner
         string contextTypeFqn,
         HashSet<string> perCommandSet)
     {
-        var orderedCommands = GetKeysInStableOrder(perCommandSet);
+        var orderedCommands = PipelineOrdering.GetStringsInStableOrder(perCommandSet);
 
         for (var i = 0; i < orderedCommands.Length; i++)
         {
@@ -107,7 +107,7 @@ internal static class PipelineRegistrationPlanner
         HashSet<string> policyCommandSet,
         Dictionary<string, string> commandToPolicyPipeline)
     {
-        var orderedCommands = GetKeysInStableOrder(policyCommandSet);
+        var orderedCommands = PipelineOrdering.GetStringsInStableOrder(policyCommandSet);
 
         for (var i = 0; i < orderedCommands.Length; i++)
         {
@@ -190,27 +190,4 @@ internal static class PipelineRegistrationPlanner
             ImplementationTypeExpression: $"global::{generatedNamespace}.TinyDispatcherGlobalPipeline<{command}>"));
     }
 
-    private static string[] GetKeysInStableOrder(IEnumerable<string> keys)
-    {
-        var ordered = new List<string>();
-        foreach (var key in keys)
-        {
-            ordered.Add(key);
-        }
-
-        ordered.Sort(StringComparer.Ordinal);
-        return CopyStringsToArray(ordered);
-    }
-
-    private static string[] CopyStringsToArray(List<string> values)
-    {
-        var result = new string[values.Count];
-
-        for (var i = 0; i < values.Count; i++)
-        {
-            result[i] = values[i];
-        }
-
-        return result;
-    }
 }

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineSourceWriter.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineSourceWriter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using TinyDispatcher.SourceGen.Generator.Models;
-using static TinyDispatcher.SourceGen.Emitters.Pipelines.PipelineEmitter;
 
 namespace TinyDispatcher.SourceGen.Emitters.Pipelines;
 

--- a/src/TinyDispatcher.SourceGen/Generator/GeneratorGenerationPhase.cs
+++ b/src/TinyDispatcher.SourceGen/Generator/GeneratorGenerationPhase.cs
@@ -22,13 +22,19 @@ internal sealed class GeneratorGenerationPhase
         var emitOptions = BuildEmitOptions(analysis, validationContext);
         var shouldEmitPipelines = ShouldEmitPipelines(validationContext);
 
-        new ModuleInitializerEmitter().Emit(
-            context,
+        var moduleInitializerPlan = ModuleInitializerPlanner.Build(
             extraction.Discovery,
             emitOptions,
             hasPipelineContributions: shouldEmitPipelines);
-        new EmptyPipelineContributionEmitter().Emit(context, extraction.Discovery, emitOptions);
-        new HandlerRegistrationsEmitter().Emit(context, extraction.Discovery, emitOptions);
+
+        new ModuleInitializerEmitter().Emit(context, moduleInitializerPlan);
+        new EmptyPipelineContributionEmitter().Emit(context, emitOptions);
+
+        var handlerRegistrationsPlan = HandlerRegistrationsPlanner.Build(
+            extraction.Discovery,
+            emitOptions);
+
+        new HandlerRegistrationsEmitter().Emit(context, handlerRegistrationsPlan);
 
         if (emitOptions.EmitPipelineMap)
         {
@@ -44,11 +50,19 @@ internal sealed class GeneratorGenerationPhase
             return;
         }
 
-        new PipelineEmitter(
+        var pipelinePlan = PipelinePlanner.Build(
                 validationContext.Globals,
                 validationContext.PerCommand,
-                validationContext.Policies)
-            .Emit(context, extraction.Discovery, emitOptions);
+                validationContext.Policies,
+                extraction.Discovery,
+                emitOptions);
+
+        if (!pipelinePlan.ShouldEmit)
+        {
+            return;
+        }
+
+        new PipelineEmitter().Emit(context, pipelinePlan);
     }
 
     private static GeneratorOptions BuildEmitOptions(

--- a/src/TinyDispatcher.SourceGen/SourceGenAbstractions.cs
+++ b/src/TinyDispatcher.SourceGen/SourceGenAbstractions.cs
@@ -17,14 +17,6 @@ namespace TinyDispatcher.SourceGen.Abstractions
     }
 
     // ---------------------------------------------------------------------
-    // Emitter abstraction (ModuleInitializerEmitter, ContributionEmitter, etc.)
-    // ---------------------------------------------------------------------
-    internal interface ICodeEmitter
-    {
-        void Emit(IGeneratorContext context, DiscoveryResult result, GeneratorOptions options);
-    }
-
-    // ---------------------------------------------------------------------
     // Handler discovery abstraction (RoslynHandlerDiscovery implements this)
     // ---------------------------------------------------------------------
     internal interface IHandlerDiscovery

--- a/tests/TinyDispatcher.UnitTests/SourceGen/HandlerEmitter/HandlerRegistrationsEmitterTests.cs
+++ b/tests/TinyDispatcher.UnitTests/SourceGen/HandlerEmitter/HandlerRegistrationsEmitterTests.cs
@@ -34,8 +34,9 @@ public sealed class HandlerRegistrationsEmitterTests
             PipelineMapFormat: null);
 
         var sut = new HandlerRegistrationsEmitter();
+        var plan = HandlerRegistrationsPlanner.Build(result, options);
 
-        sut.Emit(ctx, result, options);
+        sut.Emit(ctx, plan);
 
         Assert.Single(ctx.Sources);
         Assert.True(ctx.Sources.ContainsKey("ThisAssemblyHandlerRegistrations.g.cs"));


### PR DESCRIPTION
## Summary
- Move source generator planning decisions out of emitter wrappers
- Remove the unused `ICodeEmitter` abstraction
- Centralize stable pipeline ordering helpers

## Tests
- `dotnet test tests\TinyDispatcher.UnitTests\TinyDispatcher.UnitTests.csproj`