### PR TITLE
Refactor pipeline map planning

### DIFF
--- a/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapOutputFormats.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapOutputFormats.cs
@@ -1,0 +1,62 @@
+#nullable enable
+
+using System;
+
+namespace TinyDispatcher.SourceGen.Emitters.PipelineMaps;
+
+internal readonly struct PipelineMapOutputFormats
+{
+    public bool EmitJson { get; }
+
+    public bool EmitMermaid { get; }
+
+    private PipelineMapOutputFormats(bool emitJson, bool emitMermaid)
+    {
+        EmitJson = emitJson;
+        EmitMermaid = emitMermaid;
+    }
+
+    public static PipelineMapOutputFormats DefaultJson()
+        => new(emitJson: true, emitMermaid: false);
+
+    public static PipelineMapOutputFormats ParseOrDefault(string? raw)
+    {
+        var parsed = Parse(raw);
+
+        if (!parsed.EmitJson && !parsed.EmitMermaid)
+        {
+            return DefaultJson();
+        }
+
+        return parsed;
+    }
+
+    private static PipelineMapOutputFormats Parse(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return DefaultJson();
+        }
+
+        var parts = raw!.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
+        var json = false;
+        var mermaid = false;
+
+        for (var i = 0; i < parts.Length; i++)
+        {
+            var part = parts[i].Trim().ToLowerInvariant();
+
+            if (part == "json")
+            {
+                json = true;
+            }
+            else if (part == "mermaid")
+            {
+                mermaid = true;
+            }
+        }
+
+        return new PipelineMapOutputFormats(json, mermaid);
+    }
+}

--- a/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsEmitter.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsEmitter.cs
@@ -1,118 +1,37 @@
-﻿#nullable enable
+#nullable enable
 
-using System;
-using System.Collections.Immutable;
 using TinyDispatcher.SourceGen.Abstractions;
-using TinyDispatcher.SourceGen.Generator.Models;
 
 namespace TinyDispatcher.SourceGen.Emitters.PipelineMaps;
 
 internal sealed class PipelineMapsEmitter
 {
-    private readonly ImmutableArray<MiddlewareRef> _globals;
-    private readonly ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> _perCommand;
-    private readonly ImmutableDictionary<string, PolicySpec> _policies;
-
-    public PipelineMapsEmitter(
-        ImmutableArray<MiddlewareRef> globals,
-        ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> perCommand,
-        ImmutableDictionary<string, PolicySpec> policies)
+    public void Emit(IGeneratorContext context, PipelineMapsPlan plan)
     {
-        _globals = globals;
-        _perCommand = perCommand;
-        _policies = policies;
-    }
-
-    public void Emit(IGeneratorContext context, DiscoveryResult discovery, GeneratorOptions options)
-    {
-        if (!options.EmitPipelineMap)
-            return;
-
-        if (string.IsNullOrWhiteSpace(options.CommandContextType))
-            return;
-
-        var formats = PipelineMapFormats.Parse(options.PipelineMapFormat);
-
-        // if the user typed garbage, we still want predictable output (default json)
-        if (!formats.EmitJson && !formats.EmitMermaid)
-            formats = PipelineMapFormats.DefaultJson();
-
-        var inspector = new PipelineMapInspector(_globals, _perCommand, _policies, options);
-
-        EmitCommands(context, discovery.Commands, inspector, formats);
-        EmitQueries(context, discovery.Queries, inspector, formats);
-    }
-
-    private static void EmitCommands(
-        IGeneratorContext context,
-        ImmutableArray<HandlerContract> handlers,
-        PipelineMapInspector inspector,
-        PipelineMapFormats formats)
-    {
-        for (var i = 0; i < handlers.Length; i++)
+        if (!plan.ShouldEmit)
         {
-            var d = inspector.InspectCommand(handlers[i]);
-            EmitOne(context, d, formats);
+            return;
         }
-    }
 
-    private static void EmitQueries(
-        IGeneratorContext context,
-        ImmutableArray<QueryHandlerContract> handlers,
-        PipelineMapInspector inspector,
-        PipelineMapFormats formats)
-    {
-        for (var i = 0; i < handlers.Length; i++)
+        for (var i = 0; i < plan.Descriptors.Length; i++)
         {
-            var d = inspector.InspectQuery(handlers[i]);
-            EmitOne(context, d, formats);
+            EmitOne(context, plan.Descriptors[i], plan.Formats);
         }
     }
 
     private static void EmitOne(
         IGeneratorContext context,
         PipelineDescriptor descriptor,
-        PipelineMapFormats formats)
+        PipelineMapOutputFormats formats)
     {
         if (formats.EmitJson)
-            PipelineMapJsonEmitter.Emit(context, descriptor);
-
-        if (formats.EmitMermaid)
-            PipelineMapMermaidEmitter.Emit(context, descriptor);
-    }
-
-    private readonly struct PipelineMapFormats
-    {
-        public bool EmitJson { get; }
-        public bool EmitMermaid { get; }
-
-        private PipelineMapFormats(bool emitJson, bool emitMermaid)
         {
-            EmitJson = emitJson;
-            EmitMermaid = emitMermaid;
+            PipelineMapJsonEmitter.Emit(context, descriptor);
         }
 
-        public static PipelineMapFormats DefaultJson()
-            => new(emitJson: true, emitMermaid: false);
-
-        public static PipelineMapFormats Parse(string? raw)
+        if (formats.EmitMermaid)
         {
-            if (string.IsNullOrWhiteSpace(raw))
-                return DefaultJson();
-
-            var parts = raw!.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-
-            var json = false;
-            var mermaid = false;
-
-            for (var i = 0; i < parts.Length; i++)
-            {
-                var p = parts[i].Trim().ToLowerInvariant();
-                if (p == "json") json = true;
-                else if (p == "mermaid") mermaid = true;
-            }
-
-            return new PipelineMapFormats(json, mermaid);
+            PipelineMapMermaidEmitter.Emit(context, descriptor);
         }
     }
 }

--- a/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsPlan.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsPlan.cs
@@ -1,0 +1,19 @@
+#nullable enable
+
+using System.Collections.Immutable;
+
+namespace TinyDispatcher.SourceGen.Emitters.PipelineMaps;
+
+internal sealed record PipelineMapsPlan(
+    ImmutableArray<PipelineDescriptor> Descriptors,
+    PipelineMapOutputFormats Formats)
+{
+    public bool ShouldEmit =>
+        Descriptors.Length > 0 &&
+        (Formats.EmitJson || Formats.EmitMermaid);
+
+    public static PipelineMapsPlan Empty { get; } =
+        new(
+            ImmutableArray<PipelineDescriptor>.Empty,
+            PipelineMapOutputFormats.DefaultJson());
+}

--- a/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsPlanner.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsPlanner.cs
@@ -1,0 +1,59 @@
+#nullable enable
+
+using System.Collections.Immutable;
+using TinyDispatcher.SourceGen.Generator.Models;
+
+namespace TinyDispatcher.SourceGen.Emitters.PipelineMaps;
+
+internal static class PipelineMapsPlanner
+{
+    public static PipelineMapsPlan Build(
+        DiscoveryResult discovery,
+        ImmutableArray<MiddlewareRef> globals,
+        ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> perCommand,
+        ImmutableDictionary<string, PolicySpec> policies,
+        GeneratorOptions options)
+    {
+        if (!options.EmitPipelineMap)
+        {
+            return PipelineMapsPlan.Empty;
+        }
+
+        if (string.IsNullOrWhiteSpace(options.CommandContextType))
+        {
+            return PipelineMapsPlan.Empty;
+        }
+
+        var formats = PipelineMapOutputFormats.ParseOrDefault(options.PipelineMapFormat);
+        var inspector = new PipelineMapInspector(globals, perCommand, policies, options);
+        var descriptors = ImmutableArray.CreateBuilder<PipelineDescriptor>(
+            discovery.Commands.Length + discovery.Queries.Length);
+
+        AddCommands(descriptors, discovery.Commands, inspector);
+        AddQueries(descriptors, discovery.Queries, inspector);
+
+        return new PipelineMapsPlan(descriptors.ToImmutable(), formats);
+    }
+
+    private static void AddCommands(
+        ImmutableArray<PipelineDescriptor>.Builder descriptors,
+        ImmutableArray<HandlerContract> handlers,
+        PipelineMapInspector inspector)
+    {
+        for (var i = 0; i < handlers.Length; i++)
+        {
+            descriptors.Add(inspector.InspectCommand(handlers[i]));
+        }
+    }
+
+    private static void AddQueries(
+        ImmutableArray<PipelineDescriptor>.Builder descriptors,
+        ImmutableArray<QueryHandlerContract> handlers,
+        PipelineMapInspector inspector)
+    {
+        for (var i = 0; i < handlers.Length; i++)
+        {
+            descriptors.Add(inspector.InspectQuery(handlers[i]));
+        }
+    }
+}

--- a/src/TinyDispatcher.SourceGen/Generator/GeneratorGenerationPhase.cs
+++ b/src/TinyDispatcher.SourceGen/Generator/GeneratorGenerationPhase.cs
@@ -36,14 +36,14 @@ internal sealed class GeneratorGenerationPhase
 
         new HandlerRegistrationsEmitter().Emit(context, handlerRegistrationsPlan);
 
-        if (emitOptions.EmitPipelineMap)
-        {
-            new PipelineMapsEmitter(
-                    validationContext.Globals,
-                    validationContext.PerCommand,
-                    validationContext.Policies)
-                .Emit(context, extraction.Discovery, emitOptions);
-        }
+        var pipelineMapsPlan = PipelineMapsPlanner.Build(
+            extraction.Discovery,
+            validationContext.Globals,
+            validationContext.PerCommand,
+            validationContext.Policies,
+            emitOptions);
+
+        new PipelineMapsEmitter().Emit(context, pipelineMapsPlan);
 
         if (!shouldEmitPipelines)
         {

--- a/tests/TinyDispatcher.UnitTests/SourceGen/PipelineMaps/PipelineMapsPlannerTests.cs
+++ b/tests/TinyDispatcher.UnitTests/SourceGen/PipelineMaps/PipelineMapsPlannerTests.cs
@@ -1,0 +1,61 @@
+#nullable enable
+
+using System.Collections.Immutable;
+using TinyDispatcher.SourceGen;
+using TinyDispatcher.SourceGen.Emitters.PipelineMaps;
+using TinyDispatcher.SourceGen.Generator.Models;
+using Xunit;
+
+namespace TinyDispatcher.UnitTests.SourceGen.PipelineMaps;
+
+public sealed class PipelineMapsPlannerTests
+{
+    [Fact]
+    public void Build_returns_empty_plan_when_pipeline_maps_are_disabled()
+    {
+        var plan = PipelineMapsPlanner.Build(
+            Discovery("global::MyApp.Ping", "global::MyApp.PingHandler"),
+            ImmutableArray<MiddlewareRef>.Empty,
+            ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>.Empty,
+            ImmutableDictionary<string, PolicySpec>.Empty,
+            Options(emitPipelineMap: false, pipelineMapFormat: "json"));
+
+        Assert.False(plan.ShouldEmit);
+        Assert.Empty(plan.Descriptors);
+    }
+
+    [Fact]
+    public void Build_defaults_to_json_when_format_is_unknown()
+    {
+        var plan = PipelineMapsPlanner.Build(
+            Discovery("global::MyApp.Ping", "global::MyApp.PingHandler"),
+            ImmutableArray<MiddlewareRef>.Empty,
+            ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>.Empty,
+            ImmutableDictionary<string, PolicySpec>.Empty,
+            Options(emitPipelineMap: true, pipelineMapFormat: "bogus"));
+
+        Assert.True(plan.ShouldEmit);
+        Assert.True(plan.Formats.EmitJson);
+        Assert.False(plan.Formats.EmitMermaid);
+        Assert.Single(plan.Descriptors);
+    }
+
+    private static DiscoveryResult Discovery(string commandFqn, string handlerFqn)
+    {
+        return new DiscoveryResult(
+            Commands: ImmutableArray.Create(new HandlerContract(commandFqn, handlerFqn)),
+            Queries: ImmutableArray<QueryHandlerContract>.Empty);
+    }
+
+    private static GeneratorOptions Options(bool emitPipelineMap, string? pipelineMapFormat)
+    {
+        return new GeneratorOptions(
+            GeneratedNamespace: "MyApp.Generated",
+            EmitDiExtensions: false,
+            EmitHandlerRegistrations: false,
+            IncludeNamespacePrefix: null,
+            CommandContextType: "global::MyApp.AppContext",
+            EmitPipelineMap: emitPipelineMap,
+            PipelineMapFormat: pipelineMapFormat);
+    }
+}


### PR DESCRIPTION
## Summary
- Move pipeline map option gates, format parsing, and descriptor inspection into a dedicated planner
- Introduce a small `PipelineMapsPlan` model consumed by the emitter
- Keep `PipelineMapsEmitter` focused on emitting completed map descriptors

## Tests
- `dotnet test tests\TinyDispatcher.UnitTests\TinyDispatcher.UnitTests.csproj --filter FullyQualifiedName~SourceGen`
- `dotnet test tests\TinyDispatcher.UnitTests\TinyDispatcher.UnitTests.csproj`