### PR TITLE
Centralize policy command mapping

### DIFF
--- a/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsInspector.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsInspector.cs
@@ -167,38 +167,11 @@ internal sealed class PipelineMapInspector
                 continue;
             }
 
-            AddPolicyCommands(map, p, policyType, mids);
+            var contribution = new PolicyContribution(policyType, mids);
+            PipelinePolicyCommandMap.AddFirstPolicyWins(map, p.Commands, contribution);
         }
 
         return map;
-    }
-
-    private static void AddPolicyCommands(
-        Dictionary<string, PolicyContribution> map,
-        PolicySpec policy,
-        string policyType,
-        MiddlewareRef[] middlewares)
-    {
-        var contribution = new PolicyContribution(policyType, middlewares);
-
-        for (var commandIndex = 0; commandIndex < policy.Commands.Length; commandIndex++)
-        {
-            var command = PipelineTypeNames.NormalizeFqn(policy.Commands[commandIndex]);
-            var commandIsMissing = string.IsNullOrWhiteSpace(command);
-
-            if (commandIsMissing)
-            {
-                continue;
-            }
-
-            var commandAlreadyHasPolicy = map.ContainsKey(command);
-            if (commandAlreadyHasPolicy)
-            {
-                continue;
-            }
-
-            map[command] = contribution;
-        }
     }
 
 }

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePlanner.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePlanner.cs
@@ -245,36 +245,10 @@ internal static class PipelinePlanner
                 continue;
             }
 
-            AddPolicyMiddlewaresByCommand(map, p, mids);
+            PipelinePolicyCommandMap.AddFirstPolicyWins(map, p.Commands, mids);
         }
 
         return map;
-    }
-
-    private static void AddPolicyMiddlewaresByCommand(
-        Dictionary<string, MiddlewareRef[]> map,
-        PolicySpec policy,
-        MiddlewareRef[] middlewares)
-    {
-        for (var commandIndex = 0; commandIndex < policy.Commands.Length; commandIndex++)
-        {
-            var command = PipelineTypeNames.NormalizeFqn(policy.Commands[commandIndex]);
-            var commandIsMissing = string.IsNullOrWhiteSpace(command);
-
-            if (commandIsMissing)
-            {
-                continue;
-            }
-
-            var commandAlreadyHasPolicy = map.ContainsKey(command);
-
-            if (commandAlreadyHasPolicy)
-            {
-                continue;
-            }
-
-            map[command] = middlewares;
-        }
     }
 
     private static ImmutableArray<OpenGenericRegistration> BuildOpenGenericMiddlewareRegistrations(

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePolicyCommandMap.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePolicyCommandMap.cs
@@ -1,0 +1,35 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace TinyDispatcher.SourceGen.Emitters.Pipelines;
+
+internal static class PipelinePolicyCommandMap
+{
+    public static void AddFirstPolicyWins<TValue>(
+        Dictionary<string, TValue> map,
+        ImmutableArray<string> commands,
+        TValue value)
+    {
+        for (var commandIndex = 0; commandIndex < commands.Length; commandIndex++)
+        {
+            var command = PipelineTypeNames.NormalizeFqn(commands[commandIndex]);
+            var commandIsMissing = string.IsNullOrWhiteSpace(command);
+
+            if (commandIsMissing)
+            {
+                continue;
+            }
+
+            var commandAlreadyHasPolicy = map.ContainsKey(command);
+
+            if (commandAlreadyHasPolicy)
+            {
+                continue;
+            }
+
+            map[command] = value;
+        }
+    }
+}

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineRegistrationPlanner.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineRegistrationPlanner.cs
@@ -40,7 +40,7 @@ internal static class PipelineRegistrationPlanner
             var policy = orderedPolicies[i];
             var pipelineName = GetPolicyPipelineTypeName(generatedNamespace, policy);
 
-            AddPolicyPipelineNamesByCommand(map, policy, pipelineName);
+            PipelinePolicyCommandMap.AddFirstPolicyWins(map, policy.Commands, pipelineName);
         }
 
         return map;
@@ -52,32 +52,6 @@ internal static class PipelineRegistrationPlanner
             generatedNamespace +
             ".TinyDispatcherPolicyPipeline_" +
             PipelineNameFactory.SanitizePolicyName(policy.PolicyTypeFqn);
-    }
-
-    private static void AddPolicyPipelineNamesByCommand(
-        Dictionary<string, string> map,
-        PolicySpec policy,
-        string pipelineName)
-    {
-        for (var commandIndex = 0; commandIndex < policy.Commands.Length; commandIndex++)
-        {
-            var command = PipelineTypeNames.NormalizeFqn(policy.Commands[commandIndex]);
-            var commandIsMissing = string.IsNullOrWhiteSpace(command);
-
-            if (commandIsMissing)
-            {
-                continue;
-            }
-
-            var commandAlreadyHasPolicy = map.ContainsKey(command);
-
-            if (commandAlreadyHasPolicy)
-            {
-                continue;
-            }
-
-            map[command] = pipelineName;
-        }
     }
 
     private static void AddPerCommandRegistrations(

--- a/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelinePolicyCommandMapTests.cs
+++ b/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelinePolicyCommandMapTests.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using TinyDispatcher.SourceGen.Emitters.Pipelines;
+using Xunit;
+
+namespace TinyDispatcher.UnitTests.SourceGen.PipelineEmitter;
+
+public sealed class PipelinePolicyCommandMapTests
+{
+    [Fact]
+    public void AddFirstPolicyWins_normalizes_commands_and_keeps_first_value()
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        PipelinePolicyCommandMap.AddFirstPolicyWins(
+            map,
+            ImmutableArray.Create("MyApp.Commands.Ping", "global::MyApp.Commands.Pong", ""),
+            "first");
+
+        PipelinePolicyCommandMap.AddFirstPolicyWins(
+            map,
+            ImmutableArray.Create("global::MyApp.Commands.Ping"),
+            "second");
+
+        Assert.Equal("first", map["global::MyApp.Commands.Ping"]);
+        Assert.Equal("first", map["global::MyApp.Commands.Pong"]);
+        Assert.False(map.ContainsKey(string.Empty));
+    }
+}


### PR DESCRIPTION
## Summary
- Add a shared helper for policy command normalization and first-policy-wins insertion
- Use the helper from pipeline planning, pipeline registrations, and pipeline map inspection
- Keep each caller responsible for the value associated with a policy command

## Tests
- `dotnet test tests\TinyDispatcher.UnitTests\TinyDispatcher.UnitTests.csproj --filter FullyQualifiedName~SourceGen`
- `dotnet test tests\TinyDispatcher.UnitTests\TinyDispatcher.UnitTests.csproj`