### PR TITLE
Centralize per-command middleware normalization

### DIFF
--- a/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsInspector.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsInspector.cs
@@ -20,7 +20,7 @@ internal sealed class PipelineMapInspector
         GeneratorOptions options)
     {
         _globals = PipelineMiddlewareSets.NormalizeDistinct(globals);
-        _perCommand = NormalizePerCommand(perCommand);
+        _perCommand = PipelinePerCommandMiddlewareMap.Build(perCommand);
         _policyByCommand = BuildPolicyIndex(policies);
         _contextFqn = PipelineTypeNames.NormalizeFqn(options.CommandContextType!);
     }
@@ -116,27 +116,6 @@ internal sealed class PipelineMapInspector
         }
 
         return new[] { policy.PolicyTypeFqn };
-    }
-
-    private static IReadOnlyDictionary<string, MiddlewareRef[]> NormalizePerCommand(
-        ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> perCommand)
-    {
-        var dict = new Dictionary<string, MiddlewareRef[]>(StringComparer.Ordinal);
-
-        foreach (var kv in perCommand)
-        {
-            var cmd = PipelineTypeNames.NormalizeFqn(kv.Key);
-            if (string.IsNullOrWhiteSpace(cmd))
-                continue;
-
-            var mids = PipelineMiddlewareSets.NormalizeDistinct(kv.Value);
-            if (mids.Length == 0)
-                continue;
-
-            dict[cmd] = mids;
-        }
-
-        return dict;
     }
 
     private sealed record PolicyContribution(string PolicyTypeFqn, MiddlewareRef[] Middlewares);

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePerCommandMiddlewareMap.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePerCommandMiddlewareMap.cs
@@ -1,0 +1,48 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using TinyDispatcher.SourceGen.Generator.Models;
+
+namespace TinyDispatcher.SourceGen.Emitters.Pipelines;
+
+internal static class PipelinePerCommandMiddlewareMap
+{
+    public static Dictionary<string, MiddlewareRef[]> Build(
+        ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> perCommand)
+    {
+        var normalized = new Dictionary<string, MiddlewareRef[]>(StringComparer.Ordinal);
+
+        foreach (var pair in perCommand)
+        {
+            AddNormalizedMiddlewares(normalized, pair.Key, pair.Value);
+        }
+
+        return normalized;
+    }
+
+    private static void AddNormalizedMiddlewares(
+        Dictionary<string, MiddlewareRef[]> normalized,
+        string commandType,
+        ImmutableArray<MiddlewareRef> middlewares)
+    {
+        var command = PipelineTypeNames.NormalizeFqn(commandType);
+        var commandIsMissing = string.IsNullOrWhiteSpace(command);
+
+        if (commandIsMissing)
+        {
+            return;
+        }
+
+        var distinctMiddlewares = PipelineMiddlewareSets.NormalizeDistinct(middlewares);
+        var hasNoMiddlewares = distinctMiddlewares.Length == 0;
+
+        if (hasNoMiddlewares)
+        {
+            return;
+        }
+
+        normalized[command] = distinctMiddlewares;
+    }
+}

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePlanner.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePlanner.cs
@@ -24,7 +24,7 @@ internal static class PipelinePlanner
         var global = PipelineMiddlewareSets.NormalizeDistinct(globalMiddlewares);
         var hasGlobalMiddlewares = global.Length > 0;
 
-        var perCommandMiddlewares = NormalizePerCommandMiddlewares(perCommand);
+        var perCommandMiddlewares = PipelinePerCommandMiddlewareMap.Build(perCommand);
         var commandToPolicyMiddlewares = BuildCommandToPolicyMiddlewares(policies);
         var globalPipeline = BuildGlobalPipeline(global);
 
@@ -65,43 +65,6 @@ internal static class PipelinePlanner
             PerCommandPipelines: perCommandPipelines,
             OpenGenericMiddlewareRegistrations: middlewareRegistrations,
             ServiceRegistrations: serviceRegistrations);
-    }
-
-    private static Dictionary<string, MiddlewareRef[]> NormalizePerCommandMiddlewares(
-        ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> perCommand)
-    {
-        var normalized = new Dictionary<string, MiddlewareRef[]>(StringComparer.Ordinal);
-
-        foreach (var pair in perCommand)
-        {
-            AddNormalizedPerCommandMiddlewares(normalized, pair.Key, pair.Value);
-        }
-
-        return normalized;
-    }
-
-    private static void AddNormalizedPerCommandMiddlewares(
-        Dictionary<string, MiddlewareRef[]> normalized,
-        string commandType,
-        ImmutableArray<MiddlewareRef> middlewares)
-    {
-        var command = PipelineTypeNames.NormalizeFqn(commandType);
-        var commandIsMissing = string.IsNullOrWhiteSpace(command);
-
-        if (commandIsMissing)
-        {
-            return;
-        }
-
-        var distinctMiddlewares = PipelineMiddlewareSets.NormalizeDistinct(middlewares);
-        var hasNoMiddlewares = distinctMiddlewares.Length == 0;
-
-        if (hasNoMiddlewares)
-        {
-            return;
-        }
-
-        normalized[command] = distinctMiddlewares;
     }
 
     private static PipelineDefinition? BuildGlobalPipeline(MiddlewareRef[] global)

--- a/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelinePerCommandMiddlewareMapTests.cs
+++ b/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelinePerCommandMiddlewareMapTests.cs
@@ -1,0 +1,30 @@
+#nullable enable
+
+using System.Collections.Immutable;
+using TinyDispatcher.SourceGen.Emitters.Pipelines;
+using TinyDispatcher.SourceGen.Generator.Models;
+using Xunit;
+
+namespace TinyDispatcher.UnitTests.SourceGen.PipelineEmitter;
+
+public sealed class PipelinePerCommandMiddlewareMapTests
+{
+    [Fact]
+    public void Build_normalizes_commands_and_skips_empty_entries()
+    {
+        var middleware = new MiddlewareRef(
+            OpenTypeSymbol: default!,
+            OpenTypeFqn: "MyApp.Middleware.LoggingMiddleware",
+            Arity: 2);
+
+        var map = PipelinePerCommandMiddlewareMap.Build(
+            ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>.Empty
+                .Add("MyApp.Commands.Ping", ImmutableArray.Create(middleware))
+                .Add(" ", ImmutableArray.Create(middleware))
+                .Add("MyApp.Commands.Empty", ImmutableArray<MiddlewareRef>.Empty));
+
+        Assert.Single(map);
+        Assert.True(map.ContainsKey("global::MyApp.Commands.Ping"));
+        Assert.Equal("global::MyApp.Middleware.LoggingMiddleware", map["global::MyApp.Commands.Ping"][0].OpenTypeFqn);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a shared helper for per-command middleware map normalization
- Use it from pipeline planning and pipeline map inspection
- Keep command FQN normalization and empty middleware filtering in one place

## Tests
- `dotnet test tests\TinyDispatcher.UnitTests\TinyDispatcher.UnitTests.csproj --filter FullyQualifiedName~SourceGen`
- `dotnet test tests\TinyDispatcher.UnitTests\TinyDispatcher.UnitTests.csproj`