### PR TITLE
Introduce pipeline contributions model

### DIFF
--- a/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsInspector.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsInspector.cs
@@ -14,14 +14,12 @@ internal sealed class PipelineMapInspector
     private readonly string _contextFqn;
 
     public PipelineMapInspector(
-        ImmutableArray<MiddlewareRef> globals,
-        ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> perCommand,
-        ImmutableDictionary<string, PolicySpec> policies,
+        PipelineContributions contributions,
         GeneratorOptions options)
     {
-        _globals = PipelineMiddlewareSets.NormalizeDistinct(globals);
-        _perCommand = PipelinePerCommandMiddlewareMap.Build(perCommand);
-        _policyByCommand = BuildPolicyIndex(policies);
+        _globals = contributions.Globals;
+        _perCommand = contributions.PerCommand;
+        _policyByCommand = BuildPolicyIndex(contributions.Policies);
         _contextFqn = PipelineTypeNames.NormalizeFqn(options.CommandContextType!);
     }
 

--- a/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsPlanner.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsPlanner.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System.Collections.Immutable;
+using TinyDispatcher.SourceGen.Emitters.Pipelines;
 using TinyDispatcher.SourceGen.Generator.Models;
 
 namespace TinyDispatcher.SourceGen.Emitters.PipelineMaps;
@@ -9,9 +10,7 @@ internal static class PipelineMapsPlanner
 {
     public static PipelineMapsPlan Build(
         DiscoveryResult discovery,
-        ImmutableArray<MiddlewareRef> globals,
-        ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> perCommand,
-        ImmutableDictionary<string, PolicySpec> policies,
+        PipelineContributions contributions,
         GeneratorOptions options)
     {
         if (!options.EmitPipelineMap)
@@ -25,7 +24,7 @@ internal static class PipelineMapsPlanner
         }
 
         var formats = PipelineMapOutputFormats.ParseOrDefault(options.PipelineMapFormat);
-        var inspector = new PipelineMapInspector(globals, perCommand, policies, options);
+        var inspector = new PipelineMapInspector(contributions, options);
         var descriptors = ImmutableArray.CreateBuilder<PipelineDescriptor>(
             discovery.Commands.Length + discovery.Queries.Length);
 

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineContributions.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineContributions.cs
@@ -1,0 +1,24 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using TinyDispatcher.SourceGen.Generator.Models;
+
+namespace TinyDispatcher.SourceGen.Emitters.Pipelines;
+
+internal sealed record PipelineContributions(
+    MiddlewareRef[] Globals,
+    IReadOnlyDictionary<string, MiddlewareRef[]> PerCommand,
+    ImmutableDictionary<string, PolicySpec> Policies)
+{
+    public static PipelineContributions Create(
+        ImmutableArray<MiddlewareRef> globals,
+        ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> perCommand,
+        ImmutableDictionary<string, PolicySpec> policies)
+    {
+        return new PipelineContributions(
+            Globals: PipelineMiddlewareSets.NormalizeDistinct(globals),
+            PerCommand: PipelinePerCommandMiddlewareMap.Build(perCommand),
+            Policies: policies);
+    }
+}

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePlanner.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePlanner.cs
@@ -11,9 +11,7 @@ internal static class PipelinePlanner
     private static readonly MiddlewareRef[] NoMiddlewares = Array.Empty<MiddlewareRef>();
 
     public static PipelinePlan Build(
-        ImmutableArray<MiddlewareRef> globalMiddlewares,
-        ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> perCommand,
-        ImmutableDictionary<string, PolicySpec> policies,
+        PipelineContributions contributions,
         DiscoveryResult discovery,
         GeneratorOptions options)
     {
@@ -21,10 +19,11 @@ internal static class PipelinePlanner
         var generatedNamespace = options.GeneratedNamespace;
         var contextType = PipelineTypeNames.NormalizeFqn(options.CommandContextType!);
 
-        var global = PipelineMiddlewareSets.NormalizeDistinct(globalMiddlewares);
+        var global = contributions.Globals;
         var hasGlobalMiddlewares = global.Length > 0;
 
-        var perCommandMiddlewares = PipelinePerCommandMiddlewareMap.Build(perCommand);
+        var perCommandMiddlewares = contributions.PerCommand;
+        var policies = contributions.Policies;
         var commandToPolicyMiddlewares = BuildCommandToPolicyMiddlewares(policies);
         var globalPipeline = BuildGlobalPipeline(global);
 
@@ -138,7 +137,7 @@ internal static class PipelinePlanner
 
     private static ImmutableArray<PipelineDefinition> BuildPerCommandPipelines(
         MiddlewareRef[] global,
-        Dictionary<string, MiddlewareRef[]> perCmd,
+        IReadOnlyDictionary<string, MiddlewareRef[]> perCmd,
         Dictionary<string, MiddlewareRef[]> cmdToPolicyMids)
     {
         if (perCmd.Count == 0)
@@ -216,7 +215,7 @@ internal static class PipelinePlanner
 
     private static ImmutableArray<OpenGenericRegistration> BuildOpenGenericMiddlewareRegistrations(
         MiddlewareRef[] global,
-        Dictionary<string, MiddlewareRef[]> perCommand,
+        IReadOnlyDictionary<string, MiddlewareRef[]> perCommand,
         ImmutableDictionary<string, PolicySpec> policies)
     {
         var all = new List<MiddlewareRef>(256);

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineRegistrationPlanner.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineRegistrationPlanner.cs
@@ -13,7 +13,7 @@ internal static class PipelineRegistrationPlanner
         string contextTypeFqn,
         bool hasGlobal,
         DiscoveryResult discovery,
-        Dictionary<string, MiddlewareRef[]> perCommand,
+        IReadOnlyDictionary<string, MiddlewareRef[]> perCommand,
         ImmutableDictionary<string, PolicySpec> policies)
     {
         var perCommandSet = new HashSet<string>(perCommand.Keys, StringComparer.Ordinal);

--- a/src/TinyDispatcher.SourceGen/Generator/GeneratorGenerationPhase.cs
+++ b/src/TinyDispatcher.SourceGen/Generator/GeneratorGenerationPhase.cs
@@ -21,6 +21,10 @@ internal sealed class GeneratorGenerationPhase
         var validationContext = validation.Context;
         var emitOptions = BuildEmitOptions(analysis, validationContext);
         var shouldEmitPipelines = ShouldEmitPipelines(validationContext);
+        var pipelineContributions = PipelineContributions.Create(
+            validationContext.Globals,
+            validationContext.PerCommand,
+            validationContext.Policies);
 
         var moduleInitializerPlan = ModuleInitializerPlanner.Build(
             extraction.Discovery,
@@ -38,9 +42,7 @@ internal sealed class GeneratorGenerationPhase
 
         var pipelineMapsPlan = PipelineMapsPlanner.Build(
             extraction.Discovery,
-            validationContext.Globals,
-            validationContext.PerCommand,
-            validationContext.Policies,
+            pipelineContributions,
             emitOptions);
 
         new PipelineMapsEmitter().Emit(context, pipelineMapsPlan);
@@ -51,9 +53,7 @@ internal sealed class GeneratorGenerationPhase
         }
 
         var pipelinePlan = PipelinePlanner.Build(
-                validationContext.Globals,
-                validationContext.PerCommand,
-                validationContext.Policies,
+                pipelineContributions,
                 extraction.Discovery,
                 emitOptions);
 

--- a/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelineContributionsTests.cs
+++ b/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelineContributionsTests.cs
@@ -1,0 +1,39 @@
+#nullable enable
+
+using System.Collections.Immutable;
+using TinyDispatcher.SourceGen.Emitters.Pipelines;
+using TinyDispatcher.SourceGen.Generator.Models;
+using Xunit;
+
+namespace TinyDispatcher.UnitTests.SourceGen.PipelineEmitter;
+
+public sealed class PipelineContributionsTests
+{
+    [Fact]
+    public void Create_normalizes_global_and_per_command_middlewares_once()
+    {
+        var global = Middleware("MyApp.Middleware.GlobalMiddleware");
+        var perCommand = Middleware("MyApp.Middleware.PerCommandMiddleware");
+
+        var contributions = PipelineContributions.Create(
+            ImmutableArray.Create(global),
+            ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>.Empty.Add(
+                "MyApp.Commands.Ping",
+                ImmutableArray.Create(perCommand)),
+            ImmutableDictionary<string, PolicySpec>.Empty);
+
+        Assert.Equal("global::MyApp.Middleware.GlobalMiddleware", contributions.Globals[0].OpenTypeFqn);
+        Assert.True(contributions.PerCommand.ContainsKey("global::MyApp.Commands.Ping"));
+        Assert.Equal(
+            "global::MyApp.Middleware.PerCommandMiddleware",
+            contributions.PerCommand["global::MyApp.Commands.Ping"][0].OpenTypeFqn);
+    }
+
+    private static MiddlewareRef Middleware(string openTypeFqn)
+    {
+        return new MiddlewareRef(
+            OpenTypeSymbol: default!,
+            OpenTypeFqn: openTypeFqn,
+            Arity: 2);
+    }
+}

--- a/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelinePlannerTests.cs
+++ b/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelinePlannerTests.cs
@@ -33,7 +33,7 @@ public sealed class PipelinePlannerTests
 
         var options = FakeOptions("MyApp.Generated", "global::MyApp.AppContext");
 
-        var plan = PipelinePlanner.Build(global, perCommand, policies, discovery, options);
+        var plan = PipelinePlanner.Build(Contributions(global, perCommand, policies), discovery, options);
 
         Assert.True(plan.ShouldEmit);
         Assert.NotNull(plan.GlobalPipeline);
@@ -69,7 +69,7 @@ public sealed class PipelinePlannerTests
         var discovery = FakeDiscovery("global::MyApp.CmdA", "global::MyApp.CmdB");
         var options = FakeOptions("MyApp.Generated", "global::MyApp.AppContext");
 
-        var plan = PipelinePlanner.Build(global, perCommand, policies, discovery, options);
+        var plan = PipelinePlanner.Build(Contributions(global, perCommand, policies), discovery, options);
 
         Assert.True(plan.ShouldEmit);
         Assert.Null(plan.GlobalPipeline);
@@ -104,7 +104,7 @@ public sealed class PipelinePlannerTests
         var discovery = FakeDiscovery("global::MyApp.CmdA");
         var options = FakeOptions("MyApp.Generated", "global::MyApp.AppContext");
 
-        var plan = PipelinePlanner.Build(global, perCommand, policies, discovery, options);
+        var plan = PipelinePlanner.Build(Contributions(global, perCommand, policies), discovery, options);
 
         Assert.Single(plan.PolicyPipelines);
         AssertStepNames(
@@ -133,7 +133,7 @@ public sealed class PipelinePlannerTests
         var discovery = FakeDiscovery("global::MyApp.CmdA");
         var options = FakeOptions("MyApp.Generated", "global::MyApp.AppContext");
 
-        var plan = PipelinePlanner.Build(global, perCommand, policies, discovery, options);
+        var plan = PipelinePlanner.Build(Contributions(global, perCommand, policies), discovery, options);
 
         Assert.Single(plan.PerCommandPipelines);
 
@@ -165,7 +165,7 @@ public sealed class PipelinePlannerTests
         var discovery = FakeDiscovery("global::MyApp.CmdA");
         var options = FakeOptions("MyApp.Generated", "global::MyApp.AppContext");
 
-        var plan = PipelinePlanner.Build(global, perCommand, policies, discovery, options);
+        var plan = PipelinePlanner.Build(Contributions(global, perCommand, policies), discovery, options);
 
         var reg = plan.ServiceRegistrations.Single(r =>
             r.ServiceTypeExpression.Contains("ICommandPipeline<global::MyApp.CmdA", StringComparison.Ordinal));
@@ -191,6 +191,14 @@ public sealed class PipelinePlannerTests
                 .Select(fqn => new HandlerContract(MessageTypeFqn: fqn, HandlerTypeFqn: "global::MyApp.DummyHandler"))
                 .ToImmutableArray(),
             Queries: ImmutableArray<QueryHandlerContract>.Empty);
+
+    private static PipelineContributions Contributions(
+        ImmutableArray<MiddlewareRef> globals,
+        ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> perCommand,
+        ImmutableDictionary<string, PolicySpec> policies)
+    {
+        return PipelineContributions.Create(globals, perCommand, policies);
+    }
 
     private static void AssertStepNames(ImmutableArray<MiddlewareStep> steps, params string[] expected)
     {

--- a/tests/TinyDispatcher.UnitTests/SourceGen/PipelineMaps/PipelineMapInspectorTests.cs
+++ b/tests/TinyDispatcher.UnitTests/SourceGen/PipelineMaps/PipelineMapInspectorTests.cs
@@ -3,6 +3,7 @@
 using System.Collections.Immutable;
 using TinyDispatcher.SourceGen;
 using TinyDispatcher.SourceGen.Emitters.PipelineMaps;
+using TinyDispatcher.SourceGen.Emitters.Pipelines;
 using TinyDispatcher.SourceGen.Generator.Models;
 using Xunit;
 
@@ -18,7 +19,8 @@ public sealed class PipelineMapInspectorTests
         var policies = CreatePoliciesInReverseInsertionOrder();
         var options = FakeOptions();
 
-        var sut = new PipelineMapInspector(globals, perCommand, policies, options);
+        var contributions = PipelineContributions.Create(globals, perCommand, policies);
+        var sut = new PipelineMapInspector(contributions, options);
 
         var descriptor = sut.InspectCommand(new HandlerContract(
             MessageTypeFqn: "global::MyApp.Commands.Checkout",

--- a/tests/TinyDispatcher.UnitTests/SourceGen/PipelineMaps/PipelineMapsPlannerTests.cs
+++ b/tests/TinyDispatcher.UnitTests/SourceGen/PipelineMaps/PipelineMapsPlannerTests.cs
@@ -3,6 +3,7 @@
 using System.Collections.Immutable;
 using TinyDispatcher.SourceGen;
 using TinyDispatcher.SourceGen.Emitters.PipelineMaps;
+using TinyDispatcher.SourceGen.Emitters.Pipelines;
 using TinyDispatcher.SourceGen.Generator.Models;
 using Xunit;
 
@@ -15,9 +16,7 @@ public sealed class PipelineMapsPlannerTests
     {
         var plan = PipelineMapsPlanner.Build(
             Discovery("global::MyApp.Ping", "global::MyApp.PingHandler"),
-            ImmutableArray<MiddlewareRef>.Empty,
-            ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>.Empty,
-            ImmutableDictionary<string, PolicySpec>.Empty,
+            EmptyContributions(),
             Options(emitPipelineMap: false, pipelineMapFormat: "json"));
 
         Assert.False(plan.ShouldEmit);
@@ -29,9 +28,7 @@ public sealed class PipelineMapsPlannerTests
     {
         var plan = PipelineMapsPlanner.Build(
             Discovery("global::MyApp.Ping", "global::MyApp.PingHandler"),
-            ImmutableArray<MiddlewareRef>.Empty,
-            ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>.Empty,
-            ImmutableDictionary<string, PolicySpec>.Empty,
+            EmptyContributions(),
             Options(emitPipelineMap: true, pipelineMapFormat: "bogus"));
 
         Assert.True(plan.ShouldEmit);
@@ -45,6 +42,14 @@ public sealed class PipelineMapsPlannerTests
         return new DiscoveryResult(
             Commands: ImmutableArray.Create(new HandlerContract(commandFqn, handlerFqn)),
             Queries: ImmutableArray<QueryHandlerContract>.Empty);
+    }
+
+    private static PipelineContributions EmptyContributions()
+    {
+        return PipelineContributions.Create(
+            ImmutableArray<MiddlewareRef>.Empty,
+            ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>.Empty,
+            ImmutableDictionary<string, PolicySpec>.Empty);
     }
 
     private static GeneratorOptions Options(bool emitPipelineMap, string? pipelineMapFormat)


### PR DESCRIPTION
Group normalized global and per-command middleware contributions into a small planning model consumed by pipeline and pipeline map planners.

This keeps normalization in one place for generation without changing validation inputs or generated behavior.

Tests: dotnet test tests\TinyDispatcher.UnitTests\TinyDispatcher.UnitTests.csproj