### PR TITLE
Normalize policy contributions once

### DIFF
--- a/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsInspector.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsInspector.cs
@@ -116,39 +116,21 @@ internal sealed class PipelineMapInspector
         return new[] { policy.PolicyTypeFqn };
     }
 
-    private sealed record PolicyContribution(string PolicyTypeFqn, MiddlewareRef[] Middlewares);
-
-    // First policy wins (ordered by policy type name, deterministic)
     private static IReadOnlyDictionary<string, PolicyContribution> BuildPolicyIndex(
-        ImmutableDictionary<string, PolicySpec> policies)
+        PipelinePolicyContribution[] policies)
     {
         var map = new Dictionary<string, PolicyContribution>(StringComparer.Ordinal);
 
-        var orderedPolicies = PipelineOrdering.GetPoliciesInStableOrder(policies);
-        for (var i = 0; i < orderedPolicies.Length; i++)
+        for (var i = 0; i < policies.Length; i++)
         {
-            var p = orderedPolicies[i];
-            var policyType = PipelineTypeNames.NormalizeFqn(p.PolicyTypeFqn);
-            var policyTypeIsMissing = string.IsNullOrWhiteSpace(policyType);
-
-            if (policyTypeIsMissing)
-            {
-                continue;
-            }
-
-            var mids = PipelineMiddlewareSets.NormalizeDistinct(p.Middlewares);
-            var policyHasNoMiddlewares = mids.Length == 0;
-
-            if (policyHasNoMiddlewares)
-            {
-                continue;
-            }
-
-            var contribution = new PolicyContribution(policyType, mids);
-            PipelinePolicyCommandMap.AddFirstPolicyWins(map, p.Commands, contribution);
+            var policy = policies[i];
+            var contribution = new PolicyContribution(policy.PolicyTypeFqn, policy.Middlewares);
+            PipelinePolicyCommandMap.AddFirstPolicyWins(map, policy.Commands, contribution);
         }
 
         return map;
     }
+
+    private sealed record PolicyContribution(string PolicyTypeFqn, MiddlewareRef[] Middlewares);
 
 }

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineContributions.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineContributions.cs
@@ -9,7 +9,7 @@ namespace TinyDispatcher.SourceGen.Emitters.Pipelines;
 internal sealed record PipelineContributions(
     MiddlewareRef[] Globals,
     IReadOnlyDictionary<string, MiddlewareRef[]> PerCommand,
-    ImmutableDictionary<string, PolicySpec> Policies)
+    PipelinePolicyContribution[] Policies)
 {
     public static PipelineContributions Create(
         ImmutableArray<MiddlewareRef> globals,
@@ -19,6 +19,62 @@ internal sealed record PipelineContributions(
         return new PipelineContributions(
             Globals: PipelineMiddlewareSets.NormalizeDistinct(globals),
             PerCommand: PipelinePerCommandMiddlewareMap.Build(perCommand),
-            Policies: policies);
+            Policies: BuildPolicies(policies));
+    }
+
+    private static PipelinePolicyContribution[] BuildPolicies(
+        ImmutableDictionary<string, PolicySpec> policies)
+    {
+        var orderedPolicies = PipelineOrdering.GetPoliciesInStableOrder(policies);
+        var normalizedPolicies = new List<PipelinePolicyContribution>(orderedPolicies.Length);
+
+        for (var i = 0; i < orderedPolicies.Length; i++)
+        {
+            var policy = orderedPolicies[i];
+            var policyType = PipelineTypeNames.NormalizeFqn(policy.PolicyTypeFqn);
+            var policyTypeIsMissing = string.IsNullOrWhiteSpace(policyType);
+
+            if (policyTypeIsMissing)
+            {
+                continue;
+            }
+
+            var middlewares = PipelineMiddlewareSets.NormalizeDistinct(policy.Middlewares);
+            var policyHasNoMiddlewares = middlewares.Length == 0;
+
+            if (policyHasNoMiddlewares)
+            {
+                continue;
+            }
+
+            normalizedPolicies.Add(new PipelinePolicyContribution(
+                policyType,
+                middlewares,
+                NormalizeCommands(policy.Commands)));
+        }
+
+        return normalizedPolicies.ToArray();
+    }
+
+    private static ImmutableArray<string> NormalizeCommands(ImmutableArray<string> commands)
+    {
+        if (commands.IsDefaultOrEmpty)
+        {
+            return ImmutableArray<string>.Empty;
+        }
+
+        var normalized = ImmutableArray.CreateBuilder<string>(commands.Length);
+
+        for (var i = 0; i < commands.Length; i++)
+        {
+            var command = PipelineTypeNames.NormalizeFqn(commands[i]);
+
+            if (!string.IsNullOrWhiteSpace(command))
+            {
+                normalized.Add(command);
+            }
+        }
+
+        return normalized.ToImmutable();
     }
 }

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePlanner.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePlanner.cs
@@ -104,32 +104,24 @@ internal static class PipelinePlanner
 
     private static ImmutableArray<PipelineDefinition> BuildPolicyPipelines(
         MiddlewareRef[] global,
-        ImmutableDictionary<string, PolicySpec> policies)
+        PipelinePolicyContribution[] policies)
     {
-        if (policies.Count == 0)
+        if (policies.Length == 0)
         {
             return ImmutableArray<PipelineDefinition>.Empty;
         }
 
-        var list = new List<PipelineDefinition>(policies.Count);
+        var list = new List<PipelineDefinition>(policies.Length);
 
-        var orderedPolicies = PipelineOrdering.GetPoliciesInStableOrder(policies);
-        for (var i = 0; i < orderedPolicies.Length; i++)
+        for (var i = 0; i < policies.Length; i++)
         {
-            var p = orderedPolicies[i];
-            var policyMids = PipelineMiddlewareSets.NormalizeDistinct(p.Middlewares);
-            var hasNoPolicyMiddlewares = policyMids.Length == 0;
-
-            if (hasNoPolicyMiddlewares)
-            {
-                continue;
-            }
+            var policy = policies[i];
 
             list.Add(new PipelineDefinition(
-                ClassName: "TinyDispatcherPolicyPipeline_" + PipelineNameFactory.SanitizePolicyName(p.PolicyTypeFqn),
+                ClassName: "TinyDispatcherPolicyPipeline_" + PipelineNameFactory.SanitizePolicyName(policy.PolicyTypeFqn),
                 IsOpenGeneric: true,
                 CommandType: "TCommand",
-                Steps: BuildSteps(global, policyMids, NoMiddlewares)));
+                Steps: BuildSteps(global, policy.Middlewares, NoMiddlewares)));
         }
 
         return list.ToImmutableArray();
@@ -191,23 +183,14 @@ internal static class PipelinePlanner
     }
 
     private static Dictionary<string, MiddlewareRef[]> BuildCommandToPolicyMiddlewares(
-        ImmutableDictionary<string, PolicySpec> policies)
+        PipelinePolicyContribution[] policies)
     {
         var map = new Dictionary<string, MiddlewareRef[]>(StringComparer.Ordinal);
 
-        var orderedPolicies = PipelineOrdering.GetPoliciesInStableOrder(policies);
-        for (var i = 0; i < orderedPolicies.Length; i++)
+        for (var i = 0; i < policies.Length; i++)
         {
-            var p = orderedPolicies[i];
-            var mids = PipelineMiddlewareSets.NormalizeDistinct(p.Middlewares);
-            var hasNoPolicyMiddlewares = mids.Length == 0;
-
-            if (hasNoPolicyMiddlewares)
-            {
-                continue;
-            }
-
-            PipelinePolicyCommandMap.AddFirstPolicyWins(map, p.Commands, mids);
+            var policy = policies[i];
+            PipelinePolicyCommandMap.AddFirstPolicyWins(map, policy.Commands, policy.Middlewares);
         }
 
         return map;
@@ -216,7 +199,7 @@ internal static class PipelinePlanner
     private static ImmutableArray<OpenGenericRegistration> BuildOpenGenericMiddlewareRegistrations(
         MiddlewareRef[] global,
         IReadOnlyDictionary<string, MiddlewareRef[]> perCommand,
-        ImmutableDictionary<string, PolicySpec> policies)
+        PipelinePolicyContribution[] policies)
     {
         var all = new List<MiddlewareRef>(256);
 
@@ -227,9 +210,9 @@ internal static class PipelinePlanner
             all.AddRange(pair.Value);
         }
 
-        foreach (var policy in policies.Values)
+        for (var i = 0; i < policies.Length; i++)
         {
-            all.AddRange(PipelineMiddlewareSets.NormalizeDistinct(policy.Middlewares));
+            all.AddRange(policies[i].Middlewares);
         }
 
         var distinct = PipelineMiddlewareSets.NormalizeDistinct(all.ToImmutableArray());

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePolicyContribution.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePolicyContribution.cs
@@ -1,0 +1,11 @@
+#nullable enable
+
+using System.Collections.Immutable;
+using TinyDispatcher.SourceGen.Generator.Models;
+
+namespace TinyDispatcher.SourceGen.Emitters.Pipelines;
+
+internal sealed record PipelinePolicyContribution(
+    string PolicyTypeFqn,
+    MiddlewareRef[] Middlewares,
+    ImmutableArray<string> Commands);

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineRegistrationPlanner.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineRegistrationPlanner.cs
@@ -14,7 +14,7 @@ internal static class PipelineRegistrationPlanner
         bool hasGlobal,
         DiscoveryResult discovery,
         IReadOnlyDictionary<string, MiddlewareRef[]> perCommand,
-        ImmutableDictionary<string, PolicySpec> policies)
+        PipelinePolicyContribution[] policies)
     {
         var perCommandSet = new HashSet<string>(perCommand.Keys, StringComparer.Ordinal);
         var commandToPolicyPipeline = BuildCommandToPolicyPipelineNames(generatedNamespace, policies);
@@ -30,14 +30,13 @@ internal static class PipelineRegistrationPlanner
 
     private static Dictionary<string, string> BuildCommandToPolicyPipelineNames(
         string generatedNamespace,
-        ImmutableDictionary<string, PolicySpec> policies)
+        PipelinePolicyContribution[] policies)
     {
         var map = new Dictionary<string, string>(StringComparer.Ordinal);
-        var orderedPolicies = PipelineOrdering.GetPoliciesInStableOrder(policies);
 
-        for (var i = 0; i < orderedPolicies.Length; i++)
+        for (var i = 0; i < policies.Length; i++)
         {
-            var policy = orderedPolicies[i];
+            var policy = policies[i];
             var pipelineName = GetPolicyPipelineTypeName(generatedNamespace, policy);
 
             PipelinePolicyCommandMap.AddFirstPolicyWins(map, policy.Commands, pipelineName);
@@ -46,7 +45,7 @@ internal static class PipelineRegistrationPlanner
         return map;
     }
 
-    private static string GetPolicyPipelineTypeName(string generatedNamespace, PolicySpec policy)
+    private static string GetPolicyPipelineTypeName(string generatedNamespace, PipelinePolicyContribution policy)
     {
         return "global::" +
             generatedNamespace +

--- a/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelineContributionsTests.cs
+++ b/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelineContributionsTests.cs
@@ -29,6 +29,45 @@ public sealed class PipelineContributionsTests
             contributions.PerCommand["global::MyApp.Commands.Ping"][0].OpenTypeFqn);
     }
 
+    [Fact]
+    public void Create_normalizes_policies_in_stable_order_and_skips_empty_middleware_policies()
+    {
+        var policies = ImmutableDictionary<string, PolicySpec>.Empty
+            .Add(
+                "global::MyApp.Policies.ZuluPolicy",
+                new PolicySpec(
+                    PolicyTypeFqn: "MyApp.Policies.ZuluPolicy",
+                    Middlewares: ImmutableArray.Create(Middleware("MyApp.Middleware.ZuluMiddleware")),
+                    Commands: ImmutableArray.Create("MyApp.Commands.Checkout")))
+            .Add(
+                "global::MyApp.Policies.AlphaPolicy",
+                new PolicySpec(
+                    PolicyTypeFqn: "MyApp.Policies.AlphaPolicy",
+                    Middlewares: ImmutableArray.Create(Middleware("MyApp.Middleware.AlphaMiddleware")),
+                    Commands: ImmutableArray.Create("MyApp.Commands.Checkout", " ")))
+            .Add(
+                "global::MyApp.Policies.EmptyPolicy",
+                new PolicySpec(
+                    PolicyTypeFqn: "MyApp.Policies.EmptyPolicy",
+                    Middlewares: ImmutableArray<MiddlewareRef>.Empty,
+                    Commands: ImmutableArray.Create("MyApp.Commands.Checkout")));
+
+        var contributions = PipelineContributions.Create(
+            ImmutableArray<MiddlewareRef>.Empty,
+            ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>.Empty,
+            policies);
+
+        Assert.Equal(2, contributions.Policies.Length);
+
+        Assert.Equal("global::MyApp.Policies.AlphaPolicy", contributions.Policies[0].PolicyTypeFqn);
+        Assert.Equal("global::MyApp.Middleware.AlphaMiddleware", contributions.Policies[0].Middlewares[0].OpenTypeFqn);
+        Assert.Equal(
+            new[] { "global::MyApp.Commands.Checkout" },
+            contributions.Policies[0].Commands);
+
+        Assert.Equal("global::MyApp.Policies.ZuluPolicy", contributions.Policies[1].PolicyTypeFqn);
+    }
+
     private static MiddlewareRef Middleware(string openTypeFqn)
     {
         return new MiddlewareRef(


### PR DESCRIPTION
Add a normalized PipelinePolicyContribution model and build ordered, non-empty policy contributions inside PipelineContributions.

Update pipeline planning, pipeline registration planning, and pipeline map inspection to consume normalized policy contributions instead of re-normalizing policy specs.

Tests: dotnet test tests\TinyDispatcher.UnitTests\TinyDispatcher.UnitTests.csproj