### PR TITLE
Add winning policy lookup to pipeline contributions

### DIFF
--- a/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsInspector.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/PipelineMaps/PipelineMapsInspector.cs
@@ -10,7 +10,7 @@ internal sealed class PipelineMapInspector
 {
     private readonly MiddlewareRef[] _globals;
     private readonly IReadOnlyDictionary<string, MiddlewareRef[]> _perCommand;
-    private readonly IReadOnlyDictionary<string, PolicyContribution> _policyByCommand;
+    private readonly IReadOnlyDictionary<string, PipelinePolicyContribution> _policyByCommand;
     private readonly string _contextFqn;
 
     public PipelineMapInspector(
@@ -19,7 +19,7 @@ internal sealed class PipelineMapInspector
     {
         _globals = contributions.Globals;
         _perCommand = contributions.PerCommand;
-        _policyByCommand = BuildPolicyIndex(contributions.Policies);
+        _policyByCommand = contributions.PolicyByCommand;
         _contextFqn = PipelineTypeNames.NormalizeFqn(options.CommandContextType!);
     }
 
@@ -62,7 +62,7 @@ internal sealed class PipelineMapInspector
     }
 
     // ORDER: Global -> Policy -> PerCommand (same mental model as pipelines)
-    private IReadOnlyList<MiddlewareDescriptor> Compose(string messageFqn, PolicyContribution? policy)
+    private IReadOnlyList<MiddlewareDescriptor> Compose(string messageFqn, PipelinePolicyContribution? policy)
     {
         var list = new List<MiddlewareDescriptor>();
 
@@ -81,7 +81,7 @@ internal sealed class PipelineMapInspector
         }
     }
 
-    private static void AddPolicy(List<MiddlewareDescriptor> list, PolicyContribution? policy)
+    private static void AddPolicy(List<MiddlewareDescriptor> list, PipelinePolicyContribution? policy)
     {
         if (policy is null)
         {
@@ -103,10 +103,10 @@ internal sealed class PipelineMapInspector
         Add(list, mids, "per-command");
     }
 
-    private PolicyContribution? FindPolicy(string commandFqn)
+    private PipelinePolicyContribution? FindPolicy(string commandFqn)
         => _policyByCommand.TryGetValue(commandFqn, out var p) ? p : null;
 
-    private static string[] PolicyApplied(PolicyContribution? policy)
+    private static string[] PolicyApplied(PipelinePolicyContribution? policy)
     {
         if (policy is null)
         {
@@ -115,22 +115,5 @@ internal sealed class PipelineMapInspector
 
         return new[] { policy.PolicyTypeFqn };
     }
-
-    private static IReadOnlyDictionary<string, PolicyContribution> BuildPolicyIndex(
-        PipelinePolicyContribution[] policies)
-    {
-        var map = new Dictionary<string, PolicyContribution>(StringComparer.Ordinal);
-
-        for (var i = 0; i < policies.Length; i++)
-        {
-            var policy = policies[i];
-            var contribution = new PolicyContribution(policy.PolicyTypeFqn, policy.Middlewares);
-            PipelinePolicyCommandMap.AddFirstPolicyWins(map, policy.Commands, contribution);
-        }
-
-        return map;
-    }
-
-    private sealed record PolicyContribution(string PolicyTypeFqn, MiddlewareRef[] Middlewares);
 
 }

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineContributions.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineContributions.cs
@@ -9,17 +9,21 @@ namespace TinyDispatcher.SourceGen.Emitters.Pipelines;
 internal sealed record PipelineContributions(
     MiddlewareRef[] Globals,
     IReadOnlyDictionary<string, MiddlewareRef[]> PerCommand,
-    PipelinePolicyContribution[] Policies)
+    PipelinePolicyContribution[] Policies,
+    IReadOnlyDictionary<string, PipelinePolicyContribution> PolicyByCommand)
 {
     public static PipelineContributions Create(
         ImmutableArray<MiddlewareRef> globals,
         ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> perCommand,
         ImmutableDictionary<string, PolicySpec> policies)
     {
+        var normalizedPolicies = BuildPolicies(policies);
+
         return new PipelineContributions(
             Globals: PipelineMiddlewareSets.NormalizeDistinct(globals),
             PerCommand: PipelinePerCommandMiddlewareMap.Build(perCommand),
-            Policies: BuildPolicies(policies));
+            Policies: normalizedPolicies,
+            PolicyByCommand: BuildPolicyByCommand(normalizedPolicies));
     }
 
     private static PipelinePolicyContribution[] BuildPolicies(
@@ -54,6 +58,20 @@ internal sealed record PipelineContributions(
         }
 
         return normalizedPolicies.ToArray();
+    }
+
+    private static IReadOnlyDictionary<string, PipelinePolicyContribution> BuildPolicyByCommand(
+        PipelinePolicyContribution[] policies)
+    {
+        var map = new Dictionary<string, PipelinePolicyContribution>(StringComparer.Ordinal);
+
+        for (var i = 0; i < policies.Length; i++)
+        {
+            var policy = policies[i];
+            PipelinePolicyCommandMap.AddFirstPolicyWins(map, policy.Commands, policy);
+        }
+
+        return map;
     }
 
     private static ImmutableArray<string> NormalizeCommands(ImmutableArray<string> commands)

--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePlanner.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelinePlanner.cs
@@ -24,14 +24,13 @@ internal static class PipelinePlanner
 
         var perCommandMiddlewares = contributions.PerCommand;
         var policies = contributions.Policies;
-        var commandToPolicyMiddlewares = BuildCommandToPolicyMiddlewares(policies);
         var globalPipeline = BuildGlobalPipeline(global);
 
         var policyPipelines = BuildPolicyPipelines(global, policies);
         var perCommandPipelines = BuildPerCommandPipelines(
             global,
             perCommandMiddlewares,
-            commandToPolicyMiddlewares);
+            contributions.PolicyByCommand);
 
         var middlewareRegistrations = BuildOpenGenericMiddlewareRegistrations(
             global,
@@ -130,7 +129,7 @@ internal static class PipelinePlanner
     private static ImmutableArray<PipelineDefinition> BuildPerCommandPipelines(
         MiddlewareRef[] global,
         IReadOnlyDictionary<string, MiddlewareRef[]> perCmd,
-        Dictionary<string, MiddlewareRef[]> cmdToPolicyMids)
+        IReadOnlyDictionary<string, PipelinePolicyContribution> policyByCommand)
     {
         if (perCmd.Count == 0)
         {
@@ -144,8 +143,13 @@ internal static class PipelinePlanner
         {
             var cmdFqn = orderedCommands[i];
             var perCmdMids = perCmd[cmdFqn];
+            MiddlewareRef[] policyMids;
 
-            if (!cmdToPolicyMids.TryGetValue(cmdFqn, out var policyMids))
+            if (policyByCommand.TryGetValue(cmdFqn, out var policy))
+            {
+                policyMids = policy.Middlewares;
+            }
+            else
             {
                 policyMids = NoMiddlewares;
             }
@@ -180,20 +184,6 @@ internal static class PipelinePlanner
         {
             steps.Add(new MiddlewareStep(middlewares[i]));
         }
-    }
-
-    private static Dictionary<string, MiddlewareRef[]> BuildCommandToPolicyMiddlewares(
-        PipelinePolicyContribution[] policies)
-    {
-        var map = new Dictionary<string, MiddlewareRef[]>(StringComparer.Ordinal);
-
-        for (var i = 0; i < policies.Length; i++)
-        {
-            var policy = policies[i];
-            PipelinePolicyCommandMap.AddFirstPolicyWins(map, policy.Commands, policy.Middlewares);
-        }
-
-        return map;
     }
 
     private static ImmutableArray<OpenGenericRegistration> BuildOpenGenericMiddlewareRegistrations(

--- a/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelineContributionsTests.cs
+++ b/tests/TinyDispatcher.UnitTests/SourceGen/PipelineEmitter/PipelineContributionsTests.cs
@@ -66,6 +66,11 @@ public sealed class PipelineContributionsTests
             contributions.Policies[0].Commands);
 
         Assert.Equal("global::MyApp.Policies.ZuluPolicy", contributions.Policies[1].PolicyTypeFqn);
+
+        Assert.True(contributions.PolicyByCommand.TryGetValue(
+            "global::MyApp.Commands.Checkout",
+            out var winningPolicy));
+        Assert.Equal("global::MyApp.Policies.AlphaPolicy", winningPolicy.PolicyTypeFqn);
     }
 
     private static MiddlewareRef Middleware(string openTypeFqn)


### PR DESCRIPTION
Build the command-to-policy lookup once inside PipelineContributions and reuse it from pipeline planning and pipeline map inspection.

This removes another duplicated first-policy-wins derivation while keeping generated behavior unchanged.

Tests: dotnet test tests\TinyDispatcher.UnitTests\TinyDispatcher.UnitTests.csproj