### PR TITLE
Introduce raw pipeline config model

### DIFF
--- a/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineContributions.cs
+++ b/src/TinyDispatcher.SourceGen/Emitters/Pipelines/PipelineContributions.cs
@@ -12,6 +12,14 @@ internal sealed record PipelineContributions(
     PipelinePolicyContribution[] Policies,
     IReadOnlyDictionary<string, PipelinePolicyContribution> PolicyByCommand)
 {
+    public static PipelineContributions Create(PipelineConfig pipeline)
+    {
+        return Create(
+            pipeline.Globals,
+            pipeline.PerCommand,
+            pipeline.Policies);
+    }
+
     public static PipelineContributions Create(
         ImmutableArray<MiddlewareRef> globals,
         ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> perCommand,

--- a/src/TinyDispatcher.SourceGen/Generator/GeneratorExtractionPhase.cs
+++ b/src/TinyDispatcher.SourceGen/Generator/GeneratorExtractionPhase.cs
@@ -40,9 +40,7 @@ internal sealed class GeneratorExtractionPhase
 
         return new GeneratorExtraction(
             discovery,
-            pipeline.Globals,
-            pipeline.PerCommand,
-            pipeline.Policies,
+            pipeline,
             useTinyDispatcherCalls);
     }
 
@@ -59,7 +57,7 @@ internal sealed class GeneratorExtractionPhase
         return handlerDiscovery.Discover(compilation, handlerSymbols);
     }
 
-    private PipelineExtraction ExtractPipelines(
+    private PipelineConfig ExtractPipelines(
         Compilation compilation,
         ImmutableArray<InvocationExpressionSyntax> useTinyCallsSyntax)
     {
@@ -77,14 +75,9 @@ internal sealed class GeneratorExtractionPhase
                 policyTypeSymbols);
         }
 
-        return new PipelineExtraction(
+        return new PipelineConfig(
             _ordering.OrderAndDistinctGlobals(globalEntries),
             _ordering.BuildPerCommandMap(perCommandEntries),
             _policyBuilder.Build(policyTypeSymbols));
     }
-
-    private sealed record PipelineExtraction(
-        ImmutableArray<MiddlewareRef> Globals,
-        ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> PerCommand,
-        ImmutableDictionary<string, PolicySpec> Policies);
 }

--- a/src/TinyDispatcher.SourceGen/Generator/GeneratorGenerationPhase.cs
+++ b/src/TinyDispatcher.SourceGen/Generator/GeneratorGenerationPhase.cs
@@ -21,10 +21,7 @@ internal sealed class GeneratorGenerationPhase
         var validationContext = validation.Context;
         var emitOptions = BuildEmitOptions(analysis, validationContext);
         var shouldEmitPipelines = ShouldEmitPipelines(validationContext);
-        var pipelineContributions = PipelineContributions.Create(
-            validationContext.Globals,
-            validationContext.PerCommand,
-            validationContext.Policies);
+        var pipelineContributions = PipelineContributions.Create(validationContext.Pipeline);
 
         var moduleInitializerPlan = ModuleInitializerPlanner.Build(
             extraction.Discovery,
@@ -98,13 +95,13 @@ internal sealed class GeneratorGenerationPhase
             return false;
         }
 
-        return HasAnyPipelineContributions(validationContext);
+        return HasAnyPipelineContributions(validationContext.Pipeline);
     }
 
-    private static bool HasAnyPipelineContributions(GeneratorValidationContext validationContext)
+    private static bool HasAnyPipelineContributions(PipelineConfig pipeline)
     {
-        return validationContext.Globals.Length > 0 ||
-               validationContext.PerCommand.Count > 0 ||
-               validationContext.Policies.Count > 0;
+        return pipeline.Globals.Length > 0 ||
+               pipeline.PerCommand.Count > 0 ||
+               pipeline.Policies.Count > 0;
     }
 }

--- a/src/TinyDispatcher.SourceGen/Generator/GeneratorValidationPhase.cs
+++ b/src/TinyDispatcher.SourceGen/Generator/GeneratorValidationPhase.cs
@@ -33,10 +33,7 @@ internal sealed class GeneratorValidationPhase
                 isHost: analysis.UseTinyCallsSyntax.Length > 0)
             .WithUseTinyDispatcherCalls(extraction.UseTinyDispatcherCalls)
             .WithExpectedContext(GetExpectedContextFqn(analysis.EffectiveOptions))
-            .WithPipelineConfig(
-                extraction.Globals,
-                extraction.PerCommand,
-                extraction.Policies)
+            .WithPipelineConfig(extraction.Pipeline)
             .Build();
     }
 

--- a/src/TinyDispatcher.SourceGen/Generator/Models/GeneratorExtraction.cs
+++ b/src/TinyDispatcher.SourceGen/Generator/Models/GeneratorExtraction.cs
@@ -4,7 +4,5 @@ namespace TinyDispatcher.SourceGen.Generator.Models;
 
 internal sealed record GeneratorExtraction(
     DiscoveryResult Discovery,
-    ImmutableArray<MiddlewareRef> Globals,
-    ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> PerCommand,
-    ImmutableDictionary<string, PolicySpec> Policies,
+    PipelineConfig Pipeline,
     ImmutableArray<UseTinyDispatcherCall> UseTinyDispatcherCalls);

--- a/src/TinyDispatcher.SourceGen/Generator/Models/PipelineConfig.cs
+++ b/src/TinyDispatcher.SourceGen/Generator/Models/PipelineConfig.cs
@@ -1,0 +1,8 @@
+using System.Collections.Immutable;
+
+namespace TinyDispatcher.SourceGen.Generator.Models;
+
+internal sealed record PipelineConfig(
+    ImmutableArray<MiddlewareRef> Globals,
+    ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> PerCommand,
+    ImmutableDictionary<string, PolicySpec> Policies);

--- a/src/TinyDispatcher.SourceGen/Validation/GeneratorValidationContext.cs
+++ b/src/TinyDispatcher.SourceGen/Validation/GeneratorValidationContext.cs
@@ -25,9 +25,10 @@ internal sealed class GeneratorValidationContext
 
         ExpectedContextFqn = b.ExpectedContextFqn ?? string.Empty;
 
-        Globals = b.Globals;
-        PerCommand = b.PerCommand ?? ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>.Empty;
-        Policies = b.Policies ?? ImmutableDictionary<string, PolicySpec>.Empty;
+        Pipeline = b.Pipeline ?? new PipelineConfig(
+            ImmutableArray<MiddlewareRef>.Empty,
+            ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>.Empty,
+            ImmutableDictionary<string, PolicySpec>.Empty);
 
         // Resolver cache (optional)
         _middlewareSymbolCache = b.MiddlewareSymbolCache;
@@ -46,9 +47,10 @@ internal sealed class GeneratorValidationContext
     public string ExpectedContextFqn { get; }
 
     // Pipeline config
-    public ImmutableArray<MiddlewareRef> Globals { get; }
-    public ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> PerCommand { get; }
-    public ImmutableDictionary<string, PolicySpec> Policies { get; }
+    public PipelineConfig Pipeline { get; }
+    public ImmutableArray<MiddlewareRef> Globals => Pipeline.Globals;
+    public ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> PerCommand => Pipeline.PerCommand;
+    public ImmutableDictionary<string, PolicySpec> Policies => Pipeline.Policies;
 
     private readonly ImmutableDictionary<string, INamedTypeSymbol>? _middlewareSymbolCache;
 
@@ -115,12 +117,7 @@ internal sealed class GeneratorValidationContext
 
         public string? ExpectedContextFqn { get; private set; }
 
-        public ImmutableArray<MiddlewareRef> Globals { get; private set; } =
-            ImmutableArray<MiddlewareRef>.Empty;
-
-        public ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>? PerCommand { get; private set; }
-
-        public ImmutableDictionary<string, PolicySpec>? Policies { get; private set; }
+        public PipelineConfig? Pipeline { get; private set; }
 
         public ImmutableDictionary<string, INamedTypeSymbol>? MiddlewareSymbolCache { get; private set; }
 
@@ -143,14 +140,9 @@ internal sealed class GeneratorValidationContext
             return this;
         }
 
-        public Builder WithPipelineConfig(
-            ImmutableArray<MiddlewareRef> globals,
-            ImmutableDictionary<string, ImmutableArray<MiddlewareRef>> perCommand,
-            ImmutableDictionary<string, PolicySpec> policies)
+        public Builder WithPipelineConfig(PipelineConfig pipeline)
         {
-            Globals = globals;
-            PerCommand = perCommand;
-            Policies = policies;
+            Pipeline = pipeline;
             return this;
         }
 

--- a/tests/TinyDispatcher.UnitTests/SourceGen/GeneratorGenerationPhaseTests.cs
+++ b/tests/TinyDispatcher.UnitTests/SourceGen/GeneratorGenerationPhaseTests.cs
@@ -22,14 +22,15 @@ public sealed class GeneratorGenerationPhaseTests
         var discovery = EmptyDiscovery();
         var extraction = new GeneratorExtraction(
             discovery,
-            ImmutableArray<MiddlewareRef>.Empty,
-            ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>.Empty,
-            ImmutableDictionary<string, PolicySpec>.Empty.Add(
-                "global::MyApp.Policy",
-                new PolicySpec(
+            new PipelineConfig(
+                ImmutableArray<MiddlewareRef>.Empty,
+                ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>.Empty,
+                ImmutableDictionary<string, PolicySpec>.Empty.Add(
                     "global::MyApp.Policy",
-                    ImmutableArray<MiddlewareRef>.Empty,
-                    ImmutableArray<string>.Empty)),
+                    new PolicySpec(
+                        "global::MyApp.Policy",
+                        ImmutableArray<MiddlewareRef>.Empty,
+                        ImmutableArray<string>.Empty))),
             ImmutableArray<UseTinyDispatcherCall>.Empty);
 
         var analysis = new GeneratorAnalysis(
@@ -46,10 +47,7 @@ public sealed class GeneratorGenerationPhaseTests
                     ImmutableArray<InvocationExpressionSyntax>.Empty,
                     isHost: false)
                 .WithExpectedContext("global::MyApp.AppContext")
-                .WithPipelineConfig(
-                    extraction.Globals,
-                    extraction.PerCommand,
-                    extraction.Policies)
+                .WithPipelineConfig(extraction.Pipeline)
                 .Build(),
             Diagnostics: new DiagnosticBag());
 

--- a/tests/TinyDispatcher.UnitTests/SourceGen/GeneratorValidationPhaseTests.cs
+++ b/tests/TinyDispatcher.UnitTests/SourceGen/GeneratorValidationPhaseTests.cs
@@ -22,9 +22,10 @@ public sealed class GeneratorValidationPhaseTests
         var discovery = EmptyDiscovery();
         var extraction = new GeneratorExtraction(
             discovery,
-            ImmutableArray<MiddlewareRef>.Empty,
-            ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>.Empty,
-            ImmutableDictionary<string, PolicySpec>.Empty,
+            new PipelineConfig(
+                ImmutableArray<MiddlewareRef>.Empty,
+                ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>.Empty,
+                ImmutableDictionary<string, PolicySpec>.Empty),
             ImmutableArray.Create(new UseTinyDispatcherCall(
                 "global::MyApp.AppContext",
                 Location.None)));
@@ -49,9 +50,10 @@ public sealed class GeneratorValidationPhaseTests
     {
         var extraction = new GeneratorExtraction(
             EmptyDiscovery(),
-            ImmutableArray<MiddlewareRef>.Empty,
-            ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>.Empty,
-            ImmutableDictionary<string, PolicySpec>.Empty,
+            new PipelineConfig(
+                ImmutableArray<MiddlewareRef>.Empty,
+                ImmutableDictionary<string, ImmutableArray<MiddlewareRef>>.Empty,
+                ImmutableDictionary<string, PolicySpec>.Empty),
             ImmutableArray<UseTinyDispatcherCall>.Empty);
 
         var analysis = new GeneratorAnalysis(


### PR DESCRIPTION
Bundle extracted pipeline facts into a named PipelineConfig model so extraction, validation, and generation stop passing globals, per-command middleware, and policies as parallel values.

Tests: dotnet test tests\TinyDispatcher.UnitTests\TinyDispatcher.UnitTests.csproj --filter FullyQualifiedName~SourceGen; dotnet test tests\TinyDispatcher.UnitTests\TinyDispatcher.UnitTests.csproj