### PR TITLE
Centralize discovery symbol normalization

### DIFF
--- a/src/TinyDispatcher.SourceGen/Discovery/MiddlewareRefFactory.cs
+++ b/src/TinyDispatcher.SourceGen/Discovery/MiddlewareRefFactory.cs
@@ -1,0 +1,23 @@
+#nullable enable
+
+using Microsoft.CodeAnalysis;
+using TinyDispatcher.SourceGen.Generator.Models;
+
+namespace TinyDispatcher.SourceGen.Discovery;
+
+internal static class MiddlewareRefFactory
+{
+    public static MiddlewareRef Create(INamedTypeSymbol middlewareType)
+    {
+        var open = middlewareType.OriginalDefinition;
+
+        var fqnWithArgs = Fqn.FromType(open);
+
+        var genericSuffixIndex = fqnWithArgs.IndexOf('<');
+        var baseFqn = genericSuffixIndex >= 0
+            ? fqnWithArgs.Substring(0, genericSuffixIndex)
+            : fqnWithArgs;
+
+        return new MiddlewareRef(open, baseFqn, open.Arity);
+    }
+}

--- a/src/TinyDispatcher.SourceGen/Discovery/PolicySpecBuilder.cs
+++ b/src/TinyDispatcher.SourceGen/Discovery/PolicySpecBuilder.cs
@@ -4,7 +4,6 @@ using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using TinyDispatcher.SourceGen.Generator;
 using TinyDispatcher.SourceGen.Generator.Models;
 
 namespace TinyDispatcher.SourceGen.Discovery;
@@ -34,8 +33,7 @@ internal sealed class PolicySpecBuilder
         for (var i = 0; i < policies.Count; i++)
         {
             var p = policies[i];
-            var key = Fqn.EnsureGlobal(
-                p.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+            var key = Fqn.FromType(p);
 
             var policyWasAlreadySeen = distinctPolicies.ContainsKey(key);
             if (policyWasAlreadySeen)
@@ -146,7 +144,7 @@ internal sealed class PolicySpecBuilder
             return;
         }
 
-        middlewares.Add(CreateMiddlewareRef(middlewareNamedType));
+        middlewares.Add(MiddlewareRefFactory.Create(middlewareNamedType));
     }
 
     private static void AddCommandIfPresent(AttributeData attribute, List<string> commands)
@@ -161,35 +159,9 @@ internal sealed class PolicySpecBuilder
             return;
         }
 
-        var commandFqn = Fqn.EnsureGlobal(
-            commandType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+        var commandFqn = Fqn.FromType(commandType);
 
         commands.Add(commandFqn);
-    }
-
-    private static MiddlewareRef CreateMiddlewareRef(INamedTypeSymbol middlewareType)
-    {
-        var open = middlewareType.OriginalDefinition;
-
-        var fqnWithArgs = Fqn.EnsureGlobal(
-            open.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
-
-        var baseFqn = StripGenericSuffix(fqnWithArgs);
-
-        return new MiddlewareRef(open, baseFqn, open.Arity);
-    }
-
-    private static string StripGenericSuffix(string fqn)
-    {
-        var idx = fqn.IndexOf('<');
-        var hasGenericSuffix = idx >= 0;
-
-        if (!hasGenericSuffix)
-        {
-            return fqn;
-        }
-
-        return fqn.Substring(0, idx);
     }
 
     private static bool HasAttribute(INamedTypeSymbol symbol, string fullName)

--- a/src/TinyDispatcher.SourceGen/Discovery/TinyBootstrapInvocationExtractor.cs
+++ b/src/TinyDispatcher.SourceGen/Discovery/TinyBootstrapInvocationExtractor.cs
@@ -141,7 +141,7 @@ internal sealed class TinyBootstrapInvocationExtractor
         }
 
         globals.Add(new OrderedEntry(
-            CreateMiddlewareRef(middlewareOpenType),
+            MiddlewareRefFactory.Create(middlewareOpenType),
             OrderKey.From(invocation)));
     }
 
@@ -207,12 +207,11 @@ internal sealed class TinyBootstrapInvocationExtractor
         INamedTypeSymbol middlewareOpenType,
         List<OrderedPerCommandEntry> perCommand)
     {
-        var commandFqn = Fqn.EnsureGlobal(
-            commandType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+        var commandFqn = Fqn.FromType(commandType);
 
         perCommand.Add(new OrderedPerCommandEntry(
             commandFqn,
-            CreateMiddlewareRef(middlewareOpenType),
+            MiddlewareRefFactory.Create(middlewareOpenType),
             OrderKey.From(invocation)));
     }
 
@@ -342,33 +341,8 @@ internal sealed class TinyBootstrapInvocationExtractor
             return true;
         }
 
-        var fqn = parameterType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        var fqn = Fqn.FromType(parameterType);
         return string.Equals(fqn, "global::TinyDispatcher.TinyBootstrap", StringComparison.Ordinal);
-    }
-
-    private static MiddlewareRef CreateMiddlewareRef(INamedTypeSymbol middlewareOpenType)
-    {
-        var open = middlewareOpenType.OriginalDefinition;
-
-        var fqnWithArgs = Fqn.EnsureGlobal(
-            open.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
-
-        var baseFqn = StripGenericSuffix(fqnWithArgs);
-
-        return new MiddlewareRef(open, baseFqn, open.Arity);
-    }
-
-    private static string StripGenericSuffix(string fqn)
-    {
-        var idx = fqn.IndexOf('<');
-        var hasGenericSuffix = idx >= 0;
-
-        if (!hasGenericSuffix)
-        {
-            return fqn;
-        }
-
-        return fqn.Substring(0, idx);
     }
 
     private static INamedTypeSymbol? TryExtractOpenGenericType(

--- a/src/TinyDispatcher.SourceGen/Generator/ContextInference.cs
+++ b/src/TinyDispatcher.SourceGen/Generator/ContextInference.cs
@@ -55,8 +55,7 @@ internal sealed class ContextInference
             if (ctxType is IErrorTypeSymbol)
                 continue;
 
-            var ctxFqn = Fqn.EnsureGlobal(
-                ctxType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+            var ctxFqn = Fqn.FromType(ctxType);
 
             builder.Add(new UseTinyDispatcherCall(ctxFqn, inv.GetLocation()));
         }

--- a/src/TinyDispatcher.SourceGen/Generator/Models/Fqn.cs
+++ b/src/TinyDispatcher.SourceGen/Generator/Models/Fqn.cs
@@ -1,7 +1,12 @@
-﻿namespace TinyDispatcher.SourceGen.Generator.Models;
+using Microsoft.CodeAnalysis;
+
+namespace TinyDispatcher.SourceGen.Generator.Models;
 
 internal static class Fqn
 {
     public static string EnsureGlobal(string s)
         => s.StartsWith("global::", StringComparison.Ordinal) ? s : "global::" + s;
+
+    public static string FromType(ITypeSymbol type)
+        => EnsureGlobal(type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
 }

--- a/src/TinyDispatcher.SourceGen/Generator/UseTinyDispatcherSemanticFilter.cs
+++ b/src/TinyDispatcher.SourceGen/Generator/UseTinyDispatcherSemanticFilter.cs
@@ -98,8 +98,7 @@ internal sealed class UseTinyDispatcherSemanticFilter
             return false;
         }
 
-        var firstParameterType = Fqn.EnsureGlobal(
-            method.Parameters[0].Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+        var firstParameterType = Fqn.FromType(method.Parameters[0].Type);
 
         return string.Equals(firstParameterType, ServiceCollectionFqn, StringComparison.Ordinal);
     }


### PR DESCRIPTION
Extract shared helpers for converting Roslyn symbols into normalized middleware references and fully-qualified type names.

This removes repeated symbol-to-string logic from discovery and generator filtering while keeping behavior unchanged.

Tests: dotnet test tests\TinyDispatcher.UnitTests\TinyDispatcher.UnitTests.csproj --filter FullyQualifiedName~SourceGen -v minimal; dotnet test tests\TinyDispatcher.UnitTests\TinyDispatcher.UnitTests.csproj -v minimal