### PR TITLE
Feature/tiny observability telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.3.0-beta.1 - Unreleased
+
+### Added
+- Built-in OpenTelemetry activities for commands and queries, including natural parent-child propagation, handler identity, and success, failure, or cancellation outcomes.
+- Operation execution and duration metrics through the standard `TinyDispatcher` meter.
+- Runnable console and ASP.NET Core telemetry samples covering nested dispatch, hosted-worker dispatch, failures, and cancellation.
+
+### Notes
+- Telemetry collection is opt-in. TinyDispatcher does not configure an exporter or automatically record command and query payloads.
+
 ## 1.2.0 - 2026-06-20
 
 ### Added

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.18" />
     <PackageVersion Include="OpenTelemetry" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
     <!-- Test infrastructure -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="xunit" Version="2.9.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,8 @@
     <PackageVersion Include="OpenTelemetry" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
     <!-- Test infrastructure -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="xunit" Version="2.9.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,8 @@
     <!-- Immutable collections -->
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.18" />
+    <PackageVersion Include="OpenTelemetry" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.16.0" />
     <!-- Test infrastructure -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="xunit" Version="2.9.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <!-- Immutable collections -->
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.0" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.18" />
     <!-- Test infrastructure -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="xunit" Version="2.9.2" />

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It provides a predictable, explicit, and performant command/query dispatch core 
 - **Feature-friendly `AppContext`** (optional `IFeatureInitializer`-based composition)
 - **Source-generator diagnostics** for invalid shapes/config (fail fast, no guessing)
 - **Context lanes** in `1.2.0` for module-owned contexts and typed dispatchers
+- **Built-in OpenTelemetry** traces and metrics for commands and queries
 
 ## Install
 
@@ -95,12 +96,29 @@ Use one lane by default. Add more lanes only when the application has real execu
 
 See [Multi-Lane Dispatching](docs/multi-lane-dispatching.md) for documentation and Orders/Payments sample pointers.
 
+## OpenTelemetry
+
+Built-in OpenTelemetry support will be introduced in `1.3.0-beta.1`.
+
+TinyDispatcher emits standard .NET activities and metrics for dispatched commands and queries. Operations preserve the current trace context, so they appear beneath ASP.NET Core requests, worker activities, and parent dispatches.
+
+```text
+POST /orders
+└── CreateOrderCommand
+    └── ReserveInventoryCommand
+```
+
+Collection is opt-in through the application's OpenTelemetry configuration. TinyDispatcher does not select an exporter, send telemetry by itself, or automatically record command and query payloads.
+
+See [OpenTelemetry](docs/opentelemetry.md) for registration, the telemetry contract, privacy behavior, and runnable samples.
+
 ## Documentation
 
 - [Getting Started](docs/getting-started.md)
 - [Architecture](docs/architecture.md)
 - [Multi-Assembly Composition](docs/multi-assembly-composition.md)
 - [Multi-Lane Dispatching](docs/multi-lane-dispatching.md) (`1.2.0`)
+- [OpenTelemetry](docs/opentelemetry.md)
 - [Middleware](docs/middleware.md)
 - [Pipelines & Layering](docs/pipelines.md)
 - [Context & Features](docs/context.md)
@@ -173,3 +191,4 @@ The repository contains runnable samples under `samples/`, including:
 - ASP.NET and custom context setups
 - context factory and closed-context middleware examples
 - a multi-project sample showing cross-assembly handler and pipeline composition
+- console and ASP.NET Core samples showing OpenTelemetry traces and metrics

--- a/benchmarks/TELEMETRY-RESULTS.md
+++ b/benchmarks/TELEMETRY-RESULTS.md
@@ -1,0 +1,44 @@
+# TinyDispatcher Telemetry Benchmark
+
+## Purpose
+
+Measure successful command dispatch with the current TinyDispatcher project under four native .NET telemetry listener configurations.
+
+This benchmark isolates instrumentation-listener cost. It does not include exporter, network, collector, or backend cost.
+
+## Reproduce
+
+```powershell
+dotnet run --project benchmarks/src/Telemetry.Perf/Telemetry.Perf.csproj -c Release -- --filter "*" --job Short
+```
+
+## Environment
+
+```text
+Date: 2026-08-16
+BenchmarkDotNet: 0.15.8
+OS: Windows 11 10.0.26200.9168
+CPU: Intel Core Ultra 7 165H, 16 physical / 22 logical cores
+.NET SDK: 10.0.201
+Runtime: .NET 10.0.5, X64 RyuJIT
+GC: Concurrent Workstation
+Job: ShortRun, 3 warmups, 3 measured iterations
+```
+
+## Result
+
+| Listeners | Mean | Allocated |
+| --- | ---: | ---: |
+| None | 95.50 ns | 24 B |
+| Activity | 361.26 ns | 680 B |
+| Meter | 89.18 ns | 24 B |
+| Activity and Meter | 368.52 ns | 680 B |
+
+The small timing difference between `None` and `Meter` is measurement noise in this short run; it is not evidence that enabling metrics makes dispatch faster. The useful observations are:
+
+- the no-listener dispatch remains sub-100 ns in this focused setup
+- enabling the Meter listener adds no observed managed allocation
+- a recorded Activity accounts for the observed listener allocation increase
+- adding Meter collection beside Activity collection does not add observed managed allocation
+
+These results justify retaining runtime-owned instrumentation. They do not justify a broad product performance claim. Re-run the benchmark on release candidates and representative deployment hardware before publishing performance claims.

--- a/benchmarks/TinyDispatcher.Performance.slnx
+++ b/benchmarks/TinyDispatcher.Performance.slnx
@@ -1,4 +1,5 @@
 <Solution>
   <Project Path="src/Performance.Shared/Performance.Shared.csproj" />
   <Project Path="src/Performance.Perf/Performance.Perf.csproj" />
+  <Project Path="src/Telemetry.Perf/Telemetry.Perf.csproj" />
 </Solution>

--- a/benchmarks/src/Telemetry.Perf/DispatcherTelemetryBenchmarks.cs
+++ b/benchmarks/src/Telemetry.Perf/DispatcherTelemetryBenchmarks.cs
@@ -1,0 +1,120 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using TinyDispatcher;
+using TinyDispatcher.Context;
+using TinyDispatcher.Dispatching;
+
+namespace Telemetry.Perf;
+
+[MemoryDiagnoser]
+public class DispatcherTelemetryBenchmarks
+{
+    private ServiceProvider _services = default!;
+    private IDispatcher<BenchmarkContext> _dispatcher = default!;
+    private ActivityListener? _activityListener;
+    private MeterListener? _meterListener;
+
+    [Params(
+        ListenerConfiguration.None,
+        ListenerConfiguration.Activity,
+        ListenerConfiguration.Meter,
+        ListenerConfiguration.ActivityAndMeter)]
+    public ListenerConfiguration Listeners { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        ConfigureListeners();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IContextFactory<BenchmarkContext>, BenchmarkContextFactory>();
+        services.AddSingleton<ICommandHandler<BenchmarkCommand, BenchmarkContext>, BenchmarkCommandHandler>();
+        services.AddSingleton<IDispatcher<BenchmarkContext>>(provider =>
+            new Dispatcher<BenchmarkContext>(
+                provider,
+                provider.GetRequiredService<IContextFactory<BenchmarkContext>>()));
+
+        _services = services.BuildServiceProvider();
+        _dispatcher = _services.GetRequiredService<IDispatcher<BenchmarkContext>>();
+    }
+
+    [Benchmark]
+    public Task Dispatch()
+    {
+        return _dispatcher.DispatchAsync(new BenchmarkCommand());
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _activityListener?.Dispose();
+        _meterListener?.Dispose();
+        _services.Dispose();
+    }
+
+    private void ConfigureListeners()
+    {
+        if (Listeners is ListenerConfiguration.Activity or ListenerConfiguration.ActivityAndMeter)
+        {
+            _activityListener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == TinyDispatcherTelemetry.ActivitySourceName,
+                Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                    ActivitySamplingResult.AllDataAndRecorded
+            };
+            ActivitySource.AddActivityListener(_activityListener);
+        }
+
+        if (Listeners is ListenerConfiguration.Meter or ListenerConfiguration.ActivityAndMeter)
+        {
+            _meterListener = new MeterListener
+            {
+                InstrumentPublished = static (instrument, listener) =>
+                {
+                    if (instrument.Meter.Name == TinyDispatcherTelemetry.MeterName)
+                    {
+                        listener.EnableMeasurementEvents(instrument);
+                    }
+                }
+            };
+            _meterListener.SetMeasurementEventCallback<long>(static (_, _, _, _) => { });
+            _meterListener.SetMeasurementEventCallback<double>(static (_, _, _, _) => { });
+            _meterListener.Start();
+        }
+    }
+
+    public enum ListenerConfiguration
+    {
+        None,
+        Activity,
+        Meter,
+        ActivityAndMeter
+    }
+
+    private sealed record BenchmarkCommand : ICommand;
+
+    private sealed class BenchmarkCommandHandler : ICommandHandler<BenchmarkCommand, BenchmarkContext>
+    {
+        public Task HandleAsync(
+            BenchmarkCommand command,
+            BenchmarkContext context,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class BenchmarkContext;
+
+    private sealed class BenchmarkContextFactory : IContextFactory<BenchmarkContext>
+    {
+        private static readonly BenchmarkContext Context = new();
+
+        public ValueTask<BenchmarkContext> CreateAsync(CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult(Context);
+        }
+    }
+}

--- a/benchmarks/src/Telemetry.Perf/Program.cs
+++ b/benchmarks/src/Telemetry.Perf/Program.cs
@@ -1,0 +1,3 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/benchmarks/src/Telemetry.Perf/Telemetry.Perf.csproj
+++ b/benchmarks/src/Telemetry.Perf/Telemetry.Perf.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\TinyDispatcher\TinyDispatcher.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,9 +11,11 @@ Key capabilities (high level):
 - optional **no-op context** mode (`UseTinyNoOpContext`) when you don't need context
 - optional feature composition via `AppContext` + `IFeatureInitializer`
 - **context lanes** in `1.2.0` for module-owned contexts and typed dispatchers
+- built-in **OpenTelemetry traces and metrics** for dispatched operations
 
 ## Release channels
 
+- `1.3.0-beta.1` will introduce built-in OpenTelemetry traces and metrics for dispatched commands and queries.
 - `1.2.0` is the stable line. It includes compile-time discovery, generated pipelines, explicit contexts, pluggable context factories, no-op context mode, multi-assembly composition, and context lanes.
 - `1.1.x` remains available for applications that are not ready to adopt the multi-context API.
 
@@ -23,6 +25,7 @@ Core docs:
 - [Architecture](architecture.md)
 - [Multi-Assembly Composition](multi-assembly-composition.md)
 - [Multi-Lane Dispatching](multi-lane-dispatching.md) (`1.2.0`)
+- [OpenTelemetry](opentelemetry.md)
 - [Source Generator](source-generator.md)
 - [Middleware](middleware.md)
 - [Pipelines & Layering](pipelines.md)

--- a/docs/opentelemetry.md
+++ b/docs/opentelemetry.md
@@ -1,0 +1,90 @@
+# OpenTelemetry
+
+TinyDispatcher provides built-in traces and metrics through the standard .NET diagnostics APIs.
+It does not choose an exporter or send telemetry anywhere. Applications decide whether to collect the telemetry and where to export it.
+
+This capability will be introduced in `1.3.0-beta.1`.
+
+After the beta is published, install it with:
+
+```powershell
+dotnet add package TinyDispatcher --version 1.3.0-beta.1
+```
+
+## Registration
+
+Register the TinyDispatcher activity source and meter with OpenTelemetry:
+
+```csharp
+builder.Services
+    .AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddSource(TinyDispatcherTelemetry.ActivitySourceName))
+    .WithMetrics(metrics => metrics
+        .AddMeter(TinyDispatcherTelemetry.MeterName));
+```
+
+Add the exporter and any host instrumentation required by the application. For example, an ASP.NET Core application can add its request instrumentation so dispatched operations appear beneath the request that caused them:
+
+```csharp
+.WithTracing(tracing => tracing
+    .AddAspNetCoreInstrumentation()
+    .AddSource(TinyDispatcherTelemetry.ActivitySourceName)
+    .AddOtlpExporter())
+```
+
+No TinyDispatcher activities are recorded when nothing listens to its activity source. Metrics are not collected unless the application registers its meter.
+
+## Traces
+
+TinyDispatcher creates one internal activity for each dispatched command or query. The activity uses the current `Activity` as its parent, including activities started by ASP.NET Core, a worker, or application code.
+
+Nested dispatches retain their natural trace hierarchy:
+
+```text
+POST /orders
+└── CreateOrderCommand
+    └── ReserveInventoryCommand
+```
+
+Each operation activity records:
+
+| Attribute | Description |
+| --- | --- |
+| `tiny.operation.name` | Short operation type name |
+| `tiny.operation.identity` | Fully qualified operation type name |
+| `tiny.operation.type` | `command` or `query` |
+| `tiny.operation.handler` | Fully qualified handler type name |
+| `tiny.operation.outcome` | `success`, `failure`, or `canceled` |
+
+A failure sets the activity status to `Error` and records the exception using the standard OpenTelemetry exception attributes. Cooperative cancellation records the `canceled` outcome without converting it into a failure.
+
+## Metrics
+
+The `TinyDispatcher` meter publishes:
+
+| Instrument | Type | Unit | Description |
+| --- | --- | --- | --- |
+| `tiny.operation.executions` | Counter | `{operation}` | Number of completed operations |
+| `tiny.operation.duration` | Histogram | `s` | Operation execution duration in seconds |
+
+Both instruments use these dimensions:
+
+- `tiny.operation.identity`
+- `tiny.operation.type`
+- `tiny.operation.outcome`
+
+Histogram aggregation and bucket boundaries belong to the collecting application or backend. The telemetry samples configure boundaries suitable for operations that usually complete in milliseconds.
+
+## Payload privacy
+
+TinyDispatcher does not automatically record command or query payloads. Application values such as customer identifiers, email addresses, order numbers, and request bodies are therefore not added to the telemetry contract.
+
+Applications can add business-safe attributes in their own activities when required. Sensitive or high-cardinality values should not be added to metric dimensions.
+
+## Samples
+
+- `samples/src/TinyDispatcher.Samples.Telemetry.Console` demonstrates commands, queries, nested dispatch, failure, and cancellation with console exporters.
+- `samples/src/TinyDispatcher.Samples.Telemetry.AspNetCore` demonstrates operations beneath HTTP request activities and a dispatch initiated by a hosted worker.
+
+See the [ASP.NET Core telemetry sample](../samples/src/TinyDispatcher.Samples.Telemetry.AspNetCore/README.md) for runnable PowerShell commands.

--- a/samples/TinyDispatcher.Samples.sln
+++ b/samples/TinyDispatcher.Samples.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TinyDispatcher.Samples.Mult
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TinyDispatcher.Samples.Telemetry.Console", "src\TinyDispatcher.Samples.Telemetry.Console\TinyDispatcher.Samples.Telemetry.Console.csproj", "{4C92C42F-934F-4FC8-B0E5-B1BD84FF97A2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TinyDispatcher.Samples.Telemetry.AspNetCore", "src\TinyDispatcher.Samples.Telemetry.AspNetCore\TinyDispatcher.Samples.Telemetry.AspNetCore.csproj", "{6A0F78D3-D591-4F04-BAF0-DCDFE3DFF918}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{4C92C42F-934F-4FC8-B0E5-B1BD84FF97A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4C92C42F-934F-4FC8-B0E5-B1BD84FF97A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4C92C42F-934F-4FC8-B0E5-B1BD84FF97A2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A0F78D3-D591-4F04-BAF0-DCDFE3DFF918}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A0F78D3-D591-4F04-BAF0-DCDFE3DFF918}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A0F78D3-D591-4F04-BAF0-DCDFE3DFF918}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A0F78D3-D591-4F04-BAF0-DCDFE3DFF918}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/TinyDispatcher.Samples.sln
+++ b/samples/TinyDispatcher.Samples.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TinyDispatcher.Samples.Aspn
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TinyDispatcher.Samples.MultiLaneDispatching", "src\TinyDispatcher.Samples.MultiLaneDispatching\TinyDispatcher.Samples.MultiLaneDispatching.csproj", "{D12E4700-4B97-4C20-BAA8-BCAF39F4EFB9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TinyDispatcher.Samples.Telemetry.Console", "src\TinyDispatcher.Samples.Telemetry.Console\TinyDispatcher.Samples.Telemetry.Console.csproj", "{4C92C42F-934F-4FC8-B0E5-B1BD84FF97A2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{D12E4700-4B97-4C20-BAA8-BCAF39F4EFB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D12E4700-4B97-4C20-BAA8-BCAF39F4EFB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D12E4700-4B97-4C20-BAA8-BCAF39F4EFB9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4C92C42F-934F-4FC8-B0E5-B1BD84FF97A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C92C42F-934F-4FC8-B0E5-B1BD84FF97A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C92C42F-934F-4FC8-B0E5-B1BD84FF97A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C92C42F-934F-4FC8-B0E5-B1BD84FF97A2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/src/TinyDispatcher.Samples.Telemetry.AspNetCore/Operations.cs
+++ b/samples/src/TinyDispatcher.Samples.Telemetry.AspNetCore/Operations.cs
@@ -1,0 +1,119 @@
+using TinyDispatcher.Dispatching;
+
+namespace TinyDispatcher.Samples.Telemetry.AspNetCore;
+
+public sealed record CreateOrderCommand(string OrderId, string CustomerEmail) : ICommand;
+
+public sealed class CreateOrderCommandHandler : ICommandHandler<CreateOrderCommand, TinyDispatcher.AppContext>
+{
+    private readonly IDispatcher<TinyDispatcher.AppContext> _dispatcher;
+
+    public CreateOrderCommandHandler(IDispatcher<TinyDispatcher.AppContext> dispatcher)
+    {
+        _dispatcher = dispatcher;
+    }
+
+    public Task HandleAsync(
+        CreateOrderCommand command,
+        TinyDispatcher.AppContext context,
+        CancellationToken cancellationToken = default)
+    {
+        return _dispatcher.DispatchAsync(
+            new ReserveInventoryCommand(command.OrderId),
+            cancellationToken);
+    }
+}
+
+public sealed record ReserveInventoryCommand(string OrderId) : ICommand;
+
+public sealed class ReserveInventoryCommandHandler : ICommandHandler<ReserveInventoryCommand, TinyDispatcher.AppContext>
+{
+    public Task HandleAsync(
+        ReserveInventoryCommand command,
+        TinyDispatcher.AppContext context,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+}
+
+public sealed record GetOrderStatusQuery(string OrderId) : IQuery<string>;
+
+public sealed class GetOrderStatusQueryHandler : IQueryHandler<GetOrderStatusQuery, string>
+{
+    public Task<string> HandleAsync(
+        GetOrderStatusQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult("ready");
+    }
+}
+
+public sealed record ReconcileOrdersCommand : ICommand;
+
+public sealed class ReconcileOrdersCommandHandler : ICommandHandler<ReconcileOrdersCommand, TinyDispatcher.AppContext>
+{
+    private readonly IDispatcher<TinyDispatcher.AppContext> _dispatcher;
+
+    public ReconcileOrdersCommandHandler(IDispatcher<TinyDispatcher.AppContext> dispatcher)
+    {
+        _dispatcher = dispatcher;
+    }
+
+    public async Task HandleAsync(
+        ReconcileOrdersCommand command,
+        TinyDispatcher.AppContext context,
+        CancellationToken cancellationToken = default)
+    {
+        await _dispatcher.DispatchAsync<GetPendingOrdersQuery, int>(
+            new GetPendingOrdersQuery(),
+            cancellationToken);
+    }
+}
+
+public sealed record GetPendingOrdersQuery : IQuery<int>;
+
+public sealed class GetPendingOrdersQueryHandler : IQueryHandler<GetPendingOrdersQuery, int>
+{
+    public Task<int> HandleAsync(
+        GetPendingOrdersQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(0);
+    }
+}
+
+public sealed record FailPaymentCommand : ICommand;
+
+public sealed class FailPaymentCommandHandler : ICommandHandler<FailPaymentCommand, TinyDispatcher.AppContext>
+{
+    public Task HandleAsync(
+        FailPaymentCommand command,
+        TinyDispatcher.AppContext context,
+        CancellationToken cancellationToken = default)
+    {
+        throw new PaymentDeclinedException("The payment provider declined the operation.");
+    }
+}
+
+public sealed record CancelOrderCommand : ICommand;
+
+public sealed class CancelOrderCommandHandler : ICommandHandler<CancelOrderCommand, TinyDispatcher.AppContext>
+{
+    public Task HandleAsync(
+        CancelOrderCommand command,
+        TinyDispatcher.AppContext context,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
+    }
+}
+
+public sealed class PaymentDeclinedException : Exception
+{
+    public PaymentDeclinedException(string message)
+        : base(message)
+    {
+    }
+}

--- a/samples/src/TinyDispatcher.Samples.Telemetry.AspNetCore/OrderReconciliationWorker.cs
+++ b/samples/src/TinyDispatcher.Samples.Telemetry.AspNetCore/OrderReconciliationWorker.cs
@@ -1,0 +1,43 @@
+using System.Diagnostics;
+using TinyDispatcher.Dispatching;
+
+namespace TinyDispatcher.Samples.Telemetry.AspNetCore;
+
+public static class WorkerTelemetry
+{
+    public const string ActivitySourceName = "TinyDispatcher.Samples.Telemetry.AspNetCore.Worker";
+
+    public static readonly ActivitySource ActivitySource = new(ActivitySourceName);
+}
+
+public sealed class OrderReconciliationWorker : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<OrderReconciliationWorker> _logger;
+
+    public OrderReconciliationWorker(
+        IServiceScopeFactory scopeFactory,
+        ILogger<OrderReconciliationWorker> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+
+        _logger.LogInformation("Starting the one-shot order reconciliation sample.");
+
+        using var activity = WorkerTelemetry.ActivitySource.StartActivity(
+            "order-reconciliation",
+            ActivityKind.Internal);
+        using var scope = _scopeFactory.CreateScope();
+        var dispatcher = scope.ServiceProvider
+            .GetRequiredService<IDispatcher<TinyDispatcher.AppContext>>();
+
+        await dispatcher.DispatchAsync(new ReconcileOrdersCommand(), stoppingToken);
+
+        _logger.LogInformation("Order reconciliation sample completed.");
+    }
+}

--- a/samples/src/TinyDispatcher.Samples.Telemetry.AspNetCore/Program.cs
+++ b/samples/src/TinyDispatcher.Samples.Telemetry.AspNetCore/Program.cs
@@ -5,6 +5,23 @@ using TinyDispatcher;
 using TinyDispatcher.Dispatching;
 using TinyDispatcher.Samples.Telemetry.AspNetCore;
 
+double[] operationDurationBoundariesInSeconds =
+[
+    0.001,
+    0.0025,
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1,
+    2.5,
+    5,
+    10
+];
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.UseTinyDispatcher<TinyDispatcher.AppContext>(_ => { });
@@ -22,7 +39,14 @@ builder.Services
         .AddConsoleExporter())
     .WithMetrics(metrics => metrics
         .AddMeter(TinyDispatcherTelemetry.MeterName)
-        .AddConsoleExporter());
+        .AddView(
+            "tiny.operation.duration",
+            new ExplicitBucketHistogramConfiguration
+            {
+                Boundaries = operationDurationBoundariesInSeconds
+            })
+        .AddConsoleExporter((_, metricReaderOptions) =>
+            metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = -1));
 
 var app = builder.Build();
 

--- a/samples/src/TinyDispatcher.Samples.Telemetry.AspNetCore/Program.cs
+++ b/samples/src/TinyDispatcher.Samples.Telemetry.AspNetCore/Program.cs
@@ -1,0 +1,93 @@
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using TinyDispatcher;
+using TinyDispatcher.Dispatching;
+using TinyDispatcher.Samples.Telemetry.AspNetCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.UseTinyDispatcher<TinyDispatcher.AppContext>(_ => { });
+builder.Services.AddHostedService<OrderReconciliationWorker>();
+
+builder.Services
+    .AddOpenTelemetry()
+    .ConfigureResource(resource => resource.AddService(
+        serviceName: "TinyShop.AspNetCore",
+        serviceVersion: "1.0.0"))
+    .WithTracing(tracing => tracing
+        .AddAspNetCoreInstrumentation()
+        .AddSource(WorkerTelemetry.ActivitySourceName)
+        .AddSource(TinyDispatcherTelemetry.ActivitySourceName)
+        .AddConsoleExporter())
+    .WithMetrics(metrics => metrics
+        .AddMeter(TinyDispatcherTelemetry.MeterName)
+        .AddConsoleExporter());
+
+var app = builder.Build();
+
+app.MapGet("/", () => Results.Ok(new
+{
+    sample = "TinyDispatcher OpenTelemetry ASP.NET Core",
+    worker = "Runs one reconciliation cycle after startup"
+}));
+
+app.MapPost("/orders", async (
+    CreateOrderRequest request,
+    IDispatcher<TinyDispatcher.AppContext> dispatcher,
+    CancellationToken cancellationToken) =>
+{
+    await dispatcher.DispatchAsync(
+        new CreateOrderCommand(request.OrderId, request.CustomerEmail),
+        cancellationToken);
+
+    return Results.Accepted($"/orders/{request.OrderId}");
+});
+
+app.MapGet("/orders/{orderId}", async (
+    string orderId,
+    IDispatcher<TinyDispatcher.AppContext> dispatcher,
+    CancellationToken cancellationToken) =>
+{
+    var status = await dispatcher.DispatchAsync<GetOrderStatusQuery, string>(
+        new GetOrderStatusQuery(orderId),
+        cancellationToken);
+
+    return Results.Ok(new { orderId, status });
+});
+
+app.MapPost("/payments/fail", async (
+    IDispatcher<TinyDispatcher.AppContext> dispatcher,
+    CancellationToken cancellationToken) =>
+{
+    try
+    {
+        await dispatcher.DispatchAsync(new FailPaymentCommand(), cancellationToken);
+        return Results.NoContent();
+    }
+    catch (PaymentDeclinedException exception)
+    {
+        return Results.Problem(exception.Message, statusCode: StatusCodes.Status502BadGateway);
+    }
+});
+
+app.MapPost("/orders/cancel", async (
+    IDispatcher<TinyDispatcher.AppContext> dispatcher) =>
+{
+    using var cancellation = new CancellationTokenSource();
+    cancellation.Cancel();
+
+    try
+    {
+        await dispatcher.DispatchAsync(new CancelOrderCommand(), cancellation.Token);
+        return Results.NoContent();
+    }
+    catch (OperationCanceledException)
+    {
+        return Results.Ok(new { outcome = "canceled" });
+    }
+});
+
+app.Run("http://localhost:5099");
+
+public sealed record CreateOrderRequest(string OrderId, string CustomerEmail);

--- a/samples/src/TinyDispatcher.Samples.Telemetry.AspNetCore/README.md
+++ b/samples/src/TinyDispatcher.Samples.Telemetry.AspNetCore/README.md
@@ -1,0 +1,20 @@
+# TinyDispatcher OpenTelemetry ASP.NET Core Sample
+
+Run the host:
+
+```powershell
+dotnet run --project samples/src/TinyDispatcher.Samples.Telemetry.AspNetCore
+```
+
+The self-hosted worker runs one reconciliation cycle after startup. In another terminal, send HTTP operations:
+
+```powershell
+Invoke-RestMethod -Method Post -Uri http://localhost:5099/orders -ContentType application/json -Body '{"orderId":"ORD-48291","customerEmail":"private@example.com"}'
+Invoke-RestMethod -Uri http://localhost:5099/orders/ORD-48291
+try { Invoke-RestMethod -Method Post -Uri http://localhost:5099/payments/fail } catch { $_.ErrorDetails.Message }
+Invoke-RestMethod -Method Post -Uri http://localhost:5099/orders/cancel
+```
+
+Stop the host with `Ctrl+C`. The console exporter prints traces as operations complete and flushes aggregated metrics during shutdown.
+
+The order ID and customer email are application payload values and are not emitted automatically.

--- a/samples/src/TinyDispatcher.Samples.Telemetry.AspNetCore/TinyDispatcher.Samples.Telemetry.AspNetCore.csproj
+++ b/samples/src/TinyDispatcher.Samples.Telemetry.AspNetCore/TinyDispatcher.Samples.Telemetry.AspNetCore.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\TinyDispatcher\TinyDispatcher.csproj" />
+    <ProjectReference Include="..\..\..\src\TinyDispatcher.SourceGen\TinyDispatcher.SourceGen.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/samples/src/TinyDispatcher.Samples.Telemetry.Console/Operations.cs
+++ b/samples/src/TinyDispatcher.Samples.Telemetry.Console/Operations.cs
@@ -1,0 +1,85 @@
+using TinyDispatcher.Dispatching;
+
+namespace TinyDispatcher.Samples.Telemetry.Console;
+
+public sealed record CreateOrderCommand(string OrderId, string CustomerEmail) : ICommand;
+
+public sealed class CreateOrderCommandHandler : ICommandHandler<CreateOrderCommand, TinyDispatcher.AppContext>
+{
+    private readonly IDispatcher<TinyDispatcher.AppContext> _dispatcher;
+
+    public CreateOrderCommandHandler(IDispatcher<TinyDispatcher.AppContext> dispatcher)
+    {
+        _dispatcher = dispatcher;
+    }
+
+    public async Task HandleAsync(
+        CreateOrderCommand command,
+        TinyDispatcher.AppContext context,
+        CancellationToken cancellationToken = default)
+    {
+        await _dispatcher.DispatchAsync(
+            new ReserveInventoryCommand(command.OrderId),
+            cancellationToken);
+    }
+}
+
+public sealed record ReserveInventoryCommand(string OrderId) : ICommand;
+
+public sealed class ReserveInventoryCommandHandler : ICommandHandler<ReserveInventoryCommand, TinyDispatcher.AppContext>
+{
+    public Task HandleAsync(
+        ReserveInventoryCommand command,
+        TinyDispatcher.AppContext context,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+}
+
+public sealed record GetOrderStatusQuery(string OrderId) : IQuery<string>;
+
+public sealed class GetOrderStatusQueryHandler : IQueryHandler<GetOrderStatusQuery, string>
+{
+    public Task<string> HandleAsync(
+        GetOrderStatusQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult("ready");
+    }
+}
+
+public sealed record FailPaymentCommand : ICommand;
+
+public sealed class FailPaymentCommandHandler : ICommandHandler<FailPaymentCommand, TinyDispatcher.AppContext>
+{
+    public Task HandleAsync(
+        FailPaymentCommand command,
+        TinyDispatcher.AppContext context,
+        CancellationToken cancellationToken = default)
+    {
+        throw new PaymentDeclinedException("The payment provider declined the operation.");
+    }
+}
+
+public sealed record CancelOrderCommand : ICommand;
+
+public sealed class CancelOrderCommandHandler : ICommandHandler<CancelOrderCommand, TinyDispatcher.AppContext>
+{
+    public Task HandleAsync(
+        CancelOrderCommand command,
+        TinyDispatcher.AppContext context,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
+    }
+}
+
+public sealed class PaymentDeclinedException : Exception
+{
+    public PaymentDeclinedException(string message)
+        : base(message)
+    {
+    }
+}

--- a/samples/src/TinyDispatcher.Samples.Telemetry.Console/Program.cs
+++ b/samples/src/TinyDispatcher.Samples.Telemetry.Console/Program.cs
@@ -1,0 +1,78 @@
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using TinyDispatcher;
+using TinyDispatcher.Dispatching;
+using TinyDispatcher.Samples.Telemetry.Console;
+
+const string sampleActivitySourceName = "TinyDispatcher.Samples.Telemetry.Console";
+
+var resource = ResourceBuilder.CreateDefault().AddService(
+    serviceName: "TinyShop.Console",
+    serviceVersion: "1.0.0");
+
+var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .SetResourceBuilder(resource)
+    .AddSource(sampleActivitySourceName)
+    .AddSource(TinyDispatcherTelemetry.ActivitySourceName)
+    .AddConsoleExporter()
+    .Build();
+
+var meterProvider = Sdk.CreateMeterProviderBuilder()
+    .SetResourceBuilder(resource)
+    .AddMeter(TinyDispatcherTelemetry.MeterName)
+    .AddConsoleExporter()
+    .Build();
+
+var services = new ServiceCollection();
+services.UseTinyDispatcher<TinyDispatcher.AppContext>(_ => { });
+
+await using var provider = services.BuildServiceProvider();
+var dispatcher = provider.GetRequiredService<IDispatcher<TinyDispatcher.AppContext>>();
+
+using var sampleActivitySource = new ActivitySource(sampleActivitySourceName);
+using (sampleActivitySource.StartActivity("checkout", ActivityKind.Internal))
+{
+    System.Console.WriteLine("Dispatching CreateOrderCommand with a nested ReserveInventoryCommand...");
+    await dispatcher.DispatchAsync(new CreateOrderCommand(
+        OrderId: "ORD-48291",
+        CustomerEmail: "private@example.com"));
+}
+
+System.Console.WriteLine("Dispatching GetOrderStatusQuery...");
+var status = await dispatcher.DispatchAsync<GetOrderStatusQuery, string>(
+    new GetOrderStatusQuery("ORD-48291"));
+System.Console.WriteLine($"Query result: {status}");
+
+System.Console.WriteLine("Dispatching FailPaymentCommand...");
+try
+{
+    await dispatcher.DispatchAsync(new FailPaymentCommand());
+}
+catch (PaymentDeclinedException)
+{
+    System.Console.WriteLine("Payment failure was preserved for the caller.");
+}
+
+System.Console.WriteLine("Dispatching CancelOrderCommand...");
+using (var cancellation = new CancellationTokenSource())
+{
+    cancellation.Cancel();
+
+    try
+    {
+        await dispatcher.DispatchAsync(new CancelOrderCommand(), cancellation.Token);
+    }
+    catch (OperationCanceledException)
+    {
+        System.Console.WriteLine("Cooperative cancellation was preserved for the caller.");
+    }
+}
+
+meterProvider.Dispose();
+tracerProvider.Dispose();
+
+System.Console.WriteLine("Telemetry export complete.");

--- a/samples/src/TinyDispatcher.Samples.Telemetry.Console/Program.cs
+++ b/samples/src/TinyDispatcher.Samples.Telemetry.Console/Program.cs
@@ -10,6 +10,23 @@ using TinyDispatcher.Samples.Telemetry.Console;
 
 const string sampleActivitySourceName = "TinyDispatcher.Samples.Telemetry.Console";
 
+double[] operationDurationBoundariesInSeconds =
+[
+    0.001,
+    0.0025,
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1,
+    2.5,
+    5,
+    10
+];
+
 var resource = ResourceBuilder.CreateDefault().AddService(
     serviceName: "TinyShop.Console",
     serviceVersion: "1.0.0");
@@ -24,7 +41,14 @@ var tracerProvider = Sdk.CreateTracerProviderBuilder()
 var meterProvider = Sdk.CreateMeterProviderBuilder()
     .SetResourceBuilder(resource)
     .AddMeter(TinyDispatcherTelemetry.MeterName)
-    .AddConsoleExporter()
+    .AddView(
+        "tiny.operation.duration",
+        new ExplicitBucketHistogramConfiguration
+        {
+            Boundaries = operationDurationBoundariesInSeconds
+        })
+    .AddConsoleExporter((_, metricReaderOptions) =>
+        metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = -1)
     .Build();
 
 var services = new ServiceCollection();

--- a/samples/src/TinyDispatcher.Samples.Telemetry.Console/TinyDispatcher.Samples.Telemetry.Console.csproj
+++ b/samples/src/TinyDispatcher.Samples.Telemetry.Console/TinyDispatcher.Samples.Telemetry.Console.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" VersionOverride="10.0.0" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\TinyDispatcher\TinyDispatcher.csproj" />
+    <ProjectReference Include="..\..\..\src\TinyDispatcher.SourceGen\TinyDispatcher.SourceGen.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/TinyDispatcher/Dispatching/Dispatcher.cs
+++ b/src/TinyDispatcher/Dispatching/Dispatcher.cs
@@ -32,6 +32,8 @@ public sealed class Dispatcher<TContext> : IDispatcher<TContext>
 
         var handler = _services.GetRequiredService<ICommandHandler<TCommand, TContext>>();
 
+        using var activity = DispatcherTelemetry.StartCommand<TCommand>(handler.GetType());
+
         var ctx = await _contextFactory.CreateAsync(ct).ConfigureAwait(false);
             
         var pipeline = _services.GetService<ICommandPipeline<TCommand, TContext>>();
@@ -39,19 +41,29 @@ public sealed class Dispatcher<TContext> : IDispatcher<TContext>
         if (pipeline is null)
         {
             await handler.HandleAsync(command, ctx, ct).ConfigureAwait(false);
-            return;
+        }
+        else
+        {
+            await pipeline.ExecuteAsync(command, ctx, handler, ct).ConfigureAwait(false);
         }
 
-        await pipeline.ExecuteAsync(command, ctx, handler, ct).ConfigureAwait(false);
+        DispatcherTelemetry.CompleteSuccessfully(activity);
 
     }
 
-    public Task<TResult> DispatchAsync<TQuery, TResult>(TQuery query, CancellationToken ct = default)
+    public async Task<TResult> DispatchAsync<TQuery, TResult>(TQuery query, CancellationToken ct = default)
         where TQuery : IQuery<TResult>
     {
         if (query is null) throw new ArgumentNullException(nameof(query));
 
         var handler = _services.GetRequiredService<IQueryHandler<TQuery, TResult>>();
-        return handler.HandleAsync(query, ct);
+
+        using var activity = DispatcherTelemetry.StartQuery<TQuery>(handler.GetType());
+
+        var result = await handler.HandleAsync(query, ct).ConfigureAwait(false);
+
+        DispatcherTelemetry.CompleteSuccessfully(activity);
+
+        return result;
     }
 }

--- a/src/TinyDispatcher/Dispatching/Dispatcher.cs
+++ b/src/TinyDispatcher/Dispatching/Dispatcher.cs
@@ -30,25 +30,37 @@ public sealed class Dispatcher<TContext> : IDispatcher<TContext>
     {
         if (command is null) throw new ArgumentNullException(nameof(command));
 
-        var handler = _services.GetRequiredService<ICommandHandler<TCommand, TContext>>();
+        using var activity = DispatcherTelemetry.StartCommand<TCommand>();
 
-        using var activity = DispatcherTelemetry.StartCommand<TCommand>(handler.GetType());
-
-        var ctx = await _contextFactory.CreateAsync(ct).ConfigureAwait(false);
-            
-        var pipeline = _services.GetService<ICommandPipeline<TCommand, TContext>>();
-
-        if (pipeline is null)
+        try
         {
-            await handler.HandleAsync(command, ctx, ct).ConfigureAwait(false);
+            var handler = _services.GetRequiredService<ICommandHandler<TCommand, TContext>>();
+            DispatcherTelemetry.SetHandler(activity, handler.GetType());
+
+            var ctx = await _contextFactory.CreateAsync(ct).ConfigureAwait(false);
+            var pipeline = _services.GetService<ICommandPipeline<TCommand, TContext>>();
+
+            if (pipeline is null)
+            {
+                await handler.HandleAsync(command, ctx, ct).ConfigureAwait(false);
+            }
+            else
+            {
+                await pipeline.ExecuteAsync(command, ctx, handler, ct).ConfigureAwait(false);
+            }
+
+            DispatcherTelemetry.CompleteSuccessfully(activity);
         }
-        else
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            await pipeline.ExecuteAsync(command, ctx, handler, ct).ConfigureAwait(false);
+            DispatcherTelemetry.CompleteAsCanceled(activity);
+            throw;
         }
-
-        DispatcherTelemetry.CompleteSuccessfully(activity);
-
+        catch (Exception exception)
+        {
+            DispatcherTelemetry.CompleteWithFailure(activity, exception);
+            throw;
+        }
     }
 
     public async Task<TResult> DispatchAsync<TQuery, TResult>(TQuery query, CancellationToken ct = default)
@@ -56,14 +68,28 @@ public sealed class Dispatcher<TContext> : IDispatcher<TContext>
     {
         if (query is null) throw new ArgumentNullException(nameof(query));
 
-        var handler = _services.GetRequiredService<IQueryHandler<TQuery, TResult>>();
+        using var activity = DispatcherTelemetry.StartQuery<TQuery>();
 
-        using var activity = DispatcherTelemetry.StartQuery<TQuery>(handler.GetType());
+        try
+        {
+            var handler = _services.GetRequiredService<IQueryHandler<TQuery, TResult>>();
+            DispatcherTelemetry.SetHandler(activity, handler.GetType());
 
-        var result = await handler.HandleAsync(query, ct).ConfigureAwait(false);
+            var result = await handler.HandleAsync(query, ct).ConfigureAwait(false);
 
-        DispatcherTelemetry.CompleteSuccessfully(activity);
+            DispatcherTelemetry.CompleteSuccessfully(activity);
 
-        return result;
+            return result;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            DispatcherTelemetry.CompleteAsCanceled(activity);
+            throw;
+        }
+        catch (Exception exception)
+        {
+            DispatcherTelemetry.CompleteWithFailure(activity, exception);
+            throw;
+        }
     }
 }

--- a/src/TinyDispatcher/Dispatching/Dispatcher.cs
+++ b/src/TinyDispatcher/Dispatching/Dispatcher.cs
@@ -30,12 +30,12 @@ public sealed class Dispatcher<TContext> : IDispatcher<TContext>
     {
         if (command is null) throw new ArgumentNullException(nameof(command));
 
-        using var activity = DispatcherTelemetry.StartCommand<TCommand>();
+        using var telemetry = DispatcherTelemetry.StartCommand<TCommand>();
 
         try
         {
             var handler = _services.GetRequiredService<ICommandHandler<TCommand, TContext>>();
-            DispatcherTelemetry.SetHandler(activity, handler.GetType());
+            telemetry.SetHandler(handler.GetType());
 
             var ctx = await _contextFactory.CreateAsync(ct).ConfigureAwait(false);
             var pipeline = _services.GetService<ICommandPipeline<TCommand, TContext>>();
@@ -49,16 +49,16 @@ public sealed class Dispatcher<TContext> : IDispatcher<TContext>
                 await pipeline.ExecuteAsync(command, ctx, handler, ct).ConfigureAwait(false);
             }
 
-            DispatcherTelemetry.CompleteSuccessfully(activity);
+            telemetry.CompleteSuccessfully();
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            DispatcherTelemetry.CompleteAsCanceled(activity);
+            telemetry.CompleteAsCanceled();
             throw;
         }
         catch (Exception exception)
         {
-            DispatcherTelemetry.CompleteWithFailure(activity, exception);
+            telemetry.CompleteWithFailure(exception);
             throw;
         }
     }
@@ -68,27 +68,27 @@ public sealed class Dispatcher<TContext> : IDispatcher<TContext>
     {
         if (query is null) throw new ArgumentNullException(nameof(query));
 
-        using var activity = DispatcherTelemetry.StartQuery<TQuery>();
+        using var telemetry = DispatcherTelemetry.StartQuery<TQuery>();
 
         try
         {
             var handler = _services.GetRequiredService<IQueryHandler<TQuery, TResult>>();
-            DispatcherTelemetry.SetHandler(activity, handler.GetType());
+            telemetry.SetHandler(handler.GetType());
 
             var result = await handler.HandleAsync(query, ct).ConfigureAwait(false);
 
-            DispatcherTelemetry.CompleteSuccessfully(activity);
+            telemetry.CompleteSuccessfully();
 
             return result;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            DispatcherTelemetry.CompleteAsCanceled(activity);
+            telemetry.CompleteAsCanceled();
             throw;
         }
         catch (Exception exception)
         {
-            DispatcherTelemetry.CompleteWithFailure(activity, exception);
+            telemetry.CompleteWithFailure(exception);
             throw;
         }
     }

--- a/src/TinyDispatcher/Telemetry/DispatcherTelemetry.cs
+++ b/src/TinyDispatcher/Telemetry/DispatcherTelemetry.cs
@@ -10,24 +10,32 @@ internal static class DispatcherTelemetry
     private const string OperationTypeAttribute = "tiny.operation.type";
     private const string OperationHandlerAttribute = "tiny.operation.handler";
     private const string OperationOutcomeAttribute = "tiny.operation.outcome";
+    private const string ErrorTypeAttribute = "error.type";
 
     private const string CommandOperationType = "command";
     private const string QueryOperationType = "query";
     private const string SuccessOutcome = "success";
+    private const string FailureOutcome = "failure";
+    private const string CanceledOutcome = "canceled";
 
     private static readonly ActivitySource ActivitySource = new(
         TinyDispatcherTelemetry.ActivitySourceName,
         typeof(TinyDispatcherTelemetry).Assembly.GetName().Version?.ToString());
 
-    internal static Activity? StartCommand<TCommand>(Type handlerType)
+    internal static Activity? StartCommand<TCommand>()
         where TCommand : ICommand
     {
-        return StartOperation(typeof(TCommand), handlerType, CommandOperationType);
+        return StartOperation(typeof(TCommand), CommandOperationType);
     }
 
-    internal static Activity? StartQuery<TQuery>(Type handlerType)
+    internal static Activity? StartQuery<TQuery>()
     {
-        return StartOperation(typeof(TQuery), handlerType, QueryOperationType);
+        return StartOperation(typeof(TQuery), QueryOperationType);
+    }
+
+    internal static void SetHandler(Activity? activity, Type handlerType)
+    {
+        activity?.SetTag(OperationHandlerAttribute, GetTypeIdentity(handlerType));
     }
 
     internal static void CompleteSuccessfully(Activity? activity)
@@ -35,9 +43,26 @@ internal static class DispatcherTelemetry
         activity?.SetTag(OperationOutcomeAttribute, SuccessOutcome);
     }
 
+    internal static void CompleteWithFailure(Activity? activity, Exception exception)
+    {
+        if (activity is null)
+        {
+            return;
+        }
+
+        activity.SetTag(OperationOutcomeAttribute, FailureOutcome);
+        activity.SetTag(ErrorTypeAttribute, GetTypeIdentity(exception.GetType()));
+        activity.SetStatus(ActivityStatusCode.Error, exception.Message);
+        activity.AddException(exception);
+    }
+
+    internal static void CompleteAsCanceled(Activity? activity)
+    {
+        activity?.SetTag(OperationOutcomeAttribute, CanceledOutcome);
+    }
+
     private static Activity? StartOperation(
         Type operationType,
-        Type handlerType,
         string operationKind)
     {
         var operationName = operationType.Name;
@@ -51,7 +76,6 @@ internal static class DispatcherTelemetry
         activity.SetTag(OperationNameAttribute, operationName);
         activity.SetTag(OperationIdentityAttribute, GetTypeIdentity(operationType));
         activity.SetTag(OperationTypeAttribute, operationKind);
-        activity.SetTag(OperationHandlerAttribute, GetTypeIdentity(handlerType));
 
         return activity;
     }

--- a/src/TinyDispatcher/Telemetry/DispatcherTelemetry.cs
+++ b/src/TinyDispatcher/Telemetry/DispatcherTelemetry.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Diagnostics;
+
+namespace TinyDispatcher;
+
+internal static class DispatcherTelemetry
+{
+    private const string OperationNameAttribute = "tiny.operation.name";
+    private const string OperationIdentityAttribute = "tiny.operation.identity";
+    private const string OperationTypeAttribute = "tiny.operation.type";
+    private const string OperationHandlerAttribute = "tiny.operation.handler";
+    private const string OperationOutcomeAttribute = "tiny.operation.outcome";
+
+    private const string CommandOperationType = "command";
+    private const string QueryOperationType = "query";
+    private const string SuccessOutcome = "success";
+
+    private static readonly ActivitySource ActivitySource = new(
+        TinyDispatcherTelemetry.ActivitySourceName,
+        typeof(TinyDispatcherTelemetry).Assembly.GetName().Version?.ToString());
+
+    internal static Activity? StartCommand<TCommand>(Type handlerType)
+        where TCommand : ICommand
+    {
+        return StartOperation(typeof(TCommand), handlerType, CommandOperationType);
+    }
+
+    internal static Activity? StartQuery<TQuery>(Type handlerType)
+    {
+        return StartOperation(typeof(TQuery), handlerType, QueryOperationType);
+    }
+
+    internal static void CompleteSuccessfully(Activity? activity)
+    {
+        activity?.SetTag(OperationOutcomeAttribute, SuccessOutcome);
+    }
+
+    private static Activity? StartOperation(
+        Type operationType,
+        Type handlerType,
+        string operationKind)
+    {
+        var operationName = operationType.Name;
+        var activity = ActivitySource.StartActivity(operationName, ActivityKind.Internal);
+
+        if (activity is null)
+        {
+            return null;
+        }
+
+        activity.SetTag(OperationNameAttribute, operationName);
+        activity.SetTag(OperationIdentityAttribute, GetTypeIdentity(operationType));
+        activity.SetTag(OperationTypeAttribute, operationKind);
+        activity.SetTag(OperationHandlerAttribute, GetTypeIdentity(handlerType));
+
+        return activity;
+    }
+
+    private static string GetTypeIdentity(Type type)
+    {
+        return type.FullName ?? type.Name;
+    }
+}

--- a/src/TinyDispatcher/Telemetry/DispatcherTelemetry.cs
+++ b/src/TinyDispatcher/Telemetry/DispatcherTelemetry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 
 namespace TinyDispatcher;
 
@@ -22,66 +23,130 @@ internal static class DispatcherTelemetry
         TinyDispatcherTelemetry.ActivitySourceName,
         typeof(TinyDispatcherTelemetry).Assembly.GetName().Version?.ToString());
 
-    internal static Activity? StartCommand<TCommand>()
+    private static readonly Meter Meter = new(
+        TinyDispatcherTelemetry.MeterName,
+        typeof(TinyDispatcherTelemetry).Assembly.GetName().Version?.ToString());
+
+    private static readonly Counter<long> OperationExecutions = Meter.CreateCounter<long>(
+        "tiny.operation.executions",
+        "{operation}",
+        "Number of completed TinyDispatcher operations.");
+
+    private static readonly Histogram<double> OperationDuration = Meter.CreateHistogram<double>(
+        "tiny.operation.duration",
+        "s",
+        "Duration of TinyDispatcher operations.");
+
+    internal static DispatcherOperationTelemetry StartCommand<TCommand>()
         where TCommand : ICommand
     {
         return StartOperation(typeof(TCommand), CommandOperationType);
     }
 
-    internal static Activity? StartQuery<TQuery>()
+    internal static DispatcherOperationTelemetry StartQuery<TQuery>()
     {
         return StartOperation(typeof(TQuery), QueryOperationType);
     }
 
-    internal static void SetHandler(Activity? activity, Type handlerType)
-    {
-        activity?.SetTag(OperationHandlerAttribute, GetTypeIdentity(handlerType));
-    }
-
-    internal static void CompleteSuccessfully(Activity? activity)
-    {
-        activity?.SetTag(OperationOutcomeAttribute, SuccessOutcome);
-    }
-
-    internal static void CompleteWithFailure(Activity? activity, Exception exception)
-    {
-        if (activity is null)
-        {
-            return;
-        }
-
-        activity.SetTag(OperationOutcomeAttribute, FailureOutcome);
-        activity.SetTag(ErrorTypeAttribute, GetTypeIdentity(exception.GetType()));
-        activity.SetStatus(ActivityStatusCode.Error, exception.Message);
-        activity.AddException(exception);
-    }
-
-    internal static void CompleteAsCanceled(Activity? activity)
-    {
-        activity?.SetTag(OperationOutcomeAttribute, CanceledOutcome);
-    }
-
-    private static Activity? StartOperation(
+    private static DispatcherOperationTelemetry StartOperation(
         Type operationType,
         string operationKind)
     {
+        var startTimestamp = Stopwatch.GetTimestamp();
         var operationName = operationType.Name;
+        var operationIdentity = GetTypeIdentity(operationType);
         var activity = ActivitySource.StartActivity(operationName, ActivityKind.Internal);
 
-        if (activity is null)
+        if (activity is not null)
         {
-            return null;
+            activity.SetTag(OperationNameAttribute, operationName);
+            activity.SetTag(OperationIdentityAttribute, operationIdentity);
+            activity.SetTag(OperationTypeAttribute, operationKind);
         }
 
-        activity.SetTag(OperationNameAttribute, operationName);
-        activity.SetTag(OperationIdentityAttribute, GetTypeIdentity(operationType));
-        activity.SetTag(OperationTypeAttribute, operationKind);
-
-        return activity;
+        return new DispatcherOperationTelemetry(
+            activity,
+            operationIdentity,
+            operationKind,
+            startTimestamp);
     }
 
     private static string GetTypeIdentity(Type type)
     {
         return type.FullName ?? type.Name;
+    }
+
+    private static void CompleteMeasurement(
+        DispatcherOperationTelemetry operation,
+        string outcome)
+    {
+        TagList tags = default;
+        tags.Add(OperationIdentityAttribute, operation.OperationIdentity);
+        tags.Add(OperationTypeAttribute, operation.OperationType);
+        tags.Add(OperationOutcomeAttribute, outcome);
+
+        OperationExecutions.Add(1, in tags);
+
+        var elapsedTimestamp = Stopwatch.GetTimestamp() - operation.StartTimestamp;
+        var elapsedSeconds = (double)elapsedTimestamp / Stopwatch.Frequency;
+        OperationDuration.Record(elapsedSeconds, in tags);
+    }
+
+    internal readonly struct DispatcherOperationTelemetry : IDisposable
+    {
+        private readonly Activity? _activity;
+
+        internal DispatcherOperationTelemetry(
+            Activity? activity,
+            string operationIdentity,
+            string operationType,
+            long startTimestamp)
+        {
+            _activity = activity;
+            OperationIdentity = operationIdentity;
+            OperationType = operationType;
+            StartTimestamp = startTimestamp;
+        }
+
+        internal string OperationIdentity { get; }
+
+        internal string OperationType { get; }
+
+        internal long StartTimestamp { get; }
+
+        internal void SetHandler(Type handlerType)
+        {
+            _activity?.SetTag(OperationHandlerAttribute, GetTypeIdentity(handlerType));
+        }
+
+        internal void CompleteSuccessfully()
+        {
+            _activity?.SetTag(OperationOutcomeAttribute, SuccessOutcome);
+            CompleteMeasurement(this, SuccessOutcome);
+        }
+
+        internal void CompleteWithFailure(Exception exception)
+        {
+            if (_activity is not null)
+            {
+                _activity.SetTag(OperationOutcomeAttribute, FailureOutcome);
+                _activity.SetTag(ErrorTypeAttribute, GetTypeIdentity(exception.GetType()));
+                _activity.SetStatus(ActivityStatusCode.Error, exception.Message);
+                _activity.AddException(exception);
+            }
+
+            CompleteMeasurement(this, FailureOutcome);
+        }
+
+        internal void CompleteAsCanceled()
+        {
+            _activity?.SetTag(OperationOutcomeAttribute, CanceledOutcome);
+            CompleteMeasurement(this, CanceledOutcome);
+        }
+
+        public void Dispose()
+        {
+            _activity?.Dispose();
+        }
     }
 }

--- a/src/TinyDispatcher/Telemetry/TinyDispatcherTelemetry.cs
+++ b/src/TinyDispatcher/Telemetry/TinyDispatcherTelemetry.cs
@@ -6,4 +6,6 @@ namespace TinyDispatcher;
 public static class TinyDispatcherTelemetry
 {
     public const string ActivitySourceName = "TinyDispatcher";
+
+    public const string MeterName = "TinyDispatcher";
 }

--- a/src/TinyDispatcher/Telemetry/TinyDispatcherTelemetry.cs
+++ b/src/TinyDispatcher/Telemetry/TinyDispatcherTelemetry.cs
@@ -1,0 +1,9 @@
+namespace TinyDispatcher;
+
+/// <summary>
+/// Public names used to register TinyDispatcher telemetry.
+/// </summary>
+public static class TinyDispatcherTelemetry
+{
+    public const string ActivitySourceName = "TinyDispatcher";
+}

--- a/src/TinyDispatcher/TinyDispatcher.csproj
+++ b/src/TinyDispatcher/TinyDispatcher.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
   <PropertyGroup>
     <PackagedSourceGeneratorPath>$(MSBuildThisFileDirectory)..\TinyDispatcher.SourceGen\bin\$(Configuration)\netstandard2.0\TinyDispatcher.SourceGen.dll</PackagedSourceGeneratorPath>

--- a/src/TinyDispatcher/TinyDispatcher.csproj
+++ b/src/TinyDispatcher/TinyDispatcher.csproj
@@ -30,8 +30,8 @@
     <Company>Innerwave</Company>
     <Product>TinyDispatcher</Product>
 
-    <Description>TinyDispatcher is a small, compile-time oriented dispatcher for .NET with pipelines and source generation.</Description>
-    <PackageTags>dotnet;dispatcher;mediator;pipeline;sourcegenerator;clean-architecture</PackageTags>
+    <Description>TinyDispatcher is a small, compile-time oriented dispatcher for .NET with generated pipelines, source generation, and built-in OpenTelemetry.</Description>
+    <PackageTags>dotnet;dispatcher;mediator;pipeline;sourcegenerator;clean-architecture;opentelemetry;observability</PackageTags>
 
     <PackageProjectUrl>https://github.com/george2006/TinyDispatcher</PackageProjectUrl>
     <RepositoryUrl>https://github.com/george2006/TinyDispatcher</RepositoryUrl>
@@ -45,7 +45,7 @@
    </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0-beta.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -54,24 +54,20 @@
   </ItemGroup>
   <PropertyGroup>
     <PackageReleaseNotes>
-      TinyDispatcher 1.2.0
+      TinyDispatcher 1.3.0-beta.1
 
       Added
-      - Stable multi-context / context-lane dispatching.
-      - Module-owned context types inside the same modular monolith.
-      - Strongly typed dispatcher lanes with independent context factories, handlers, middleware, policies, and generated pipelines.
-      - NoOpContext can participate as a no-context lane alongside typed context lanes.
-      - Orders/Payments multi-lane sample covering module-specific contexts and middleware.
-
-      Changed
-      - Source generator composition now models host lanes explicitly.
-      - Pipeline map emission includes lane-aware generated pipeline information.
-      - NoOpContext dispatch tests now live in the main unit test suite because no-op context is modeled as a lane.
+      - Built-in OpenTelemetry activities for dispatched commands and queries.
+      - Natural trace-parent propagation for HTTP requests, workers, application activities, and nested dispatches.
+      - Handler identity and success, failure, or cancellation outcomes on operation activities.
+      - Standard exception details and error status for failed operations.
+      - Operation execution counters and duration histograms.
+      - Console and ASP.NET Core telemetry samples.
 
       Notes
-      - 1.2.0 is the stable release of the context-lane API introduced in the 1.2.0 prerelease line.
-      - Use one lane by default. Add lanes when modules need distinct contexts or pipelines.
-      - 1.1.x remains available for applications that are not ready to adopt context lanes.
+      - Telemetry collection is opt-in through the standard TinyDispatcher ActivitySource and Meter names.
+      - TinyDispatcher does not configure exporters or automatically record command and query payloads.
+      - 1.2.0 remains the current stable release.
     </PackageReleaseNotes>
 
 

--- a/tests/TinyDispatcher.UnitTests/Telemetry/DispatcherOpenTelemetryTests.cs
+++ b/tests/TinyDispatcher.UnitTests/Telemetry/DispatcherOpenTelemetryTests.cs
@@ -1,0 +1,233 @@
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using TinyDispatcher.Context;
+using TinyDispatcher.Dispatching;
+using Xunit;
+
+namespace TinyDispatcher.UnitTests.Telemetry;
+
+[Collection(DispatcherTelemetryTestCollection.Name)]
+public sealed class DispatcherOpenTelemetryTests
+{
+    [Fact]
+    public async Task Ordinary_tracer_provider_exports_resource_parent_and_nested_operations()
+    {
+        var exportedActivities = new List<Activity>();
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(
+                serviceName: "Payments",
+                serviceVersion: "1.2.3"))
+            .SetSampler(new AlwaysOnSampler())
+            .AddSource(TinyDispatcherTelemetry.ActivitySourceName)
+            .AddInMemoryExporter(exportedActivities)
+            .Build();
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<ICommandHandler<OuterCommand, TestContext>, OuterCommandHandler>();
+            services.AddSingleton<ICommandHandler<InnerCommand, TestContext>, InnerCommandHandler>();
+        });
+
+        using var externalParent = new Activity("POST /payments").Start();
+        await provider.GetRequiredService<IDispatcher<TestContext>>().DispatchAsync(new OuterCommand());
+        externalParent.Stop();
+        tracerProvider.ForceFlush();
+
+        Assert.Equal("Payments", GetResourceValue(tracerProvider, "service.name"));
+        Assert.Equal("1.2.3", GetResourceValue(tracerProvider, "service.version"));
+
+        var outer = Assert.Single(exportedActivities, activity => activity.OperationName == nameof(OuterCommand));
+        var inner = Assert.Single(exportedActivities, activity => activity.OperationName == nameof(InnerCommand));
+
+        Assert.Equal(externalParent.SpanId, outer.ParentSpanId);
+        Assert.Equal(outer.SpanId, inner.ParentSpanId);
+        Assert.Equal(outer.TraceId, inner.TraceId);
+        Assert.Equal("success", outer.GetTagItem("tiny.operation.outcome"));
+        Assert.Equal("success", inner.GetTagItem("tiny.operation.outcome"));
+    }
+
+    [Fact]
+    public async Task Ordinary_tracer_provider_exports_failure_and_cancellation_semantics()
+    {
+        var exportedActivities = new List<Activity>();
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(TinyDispatcherTelemetry.ActivitySourceName)
+            .AddInMemoryExporter(exportedActivities)
+            .Build();
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<ICommandHandler<FailingCommand, TestContext>, FailingCommandHandler>();
+            services.AddSingleton<ICommandHandler<CanceledCommand, TestContext>, CanceledCommandHandler>();
+        });
+        var dispatcher = provider.GetRequiredService<IDispatcher<TestContext>>();
+
+        await Assert.ThrowsAsync<TestException>(() => dispatcher.DispatchAsync(new FailingCommand()));
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            dispatcher.DispatchAsync(new CanceledCommand(), cancellation.Token));
+        tracerProvider.ForceFlush();
+
+        var failure = Assert.Single(exportedActivities, activity => activity.OperationName == nameof(FailingCommand));
+        Assert.Equal(ActivityStatusCode.Error, failure.Status);
+        Assert.Equal("failure", failure.GetTagItem("tiny.operation.outcome"));
+        Assert.Equal(typeof(TestException).FullName, failure.GetTagItem("error.type"));
+        Assert.Equal("exception", Assert.Single(failure.Events).Name);
+
+        var canceled = Assert.Single(exportedActivities, activity => activity.OperationName == nameof(CanceledCommand));
+        Assert.Equal(ActivityStatusCode.Unset, canceled.Status);
+        Assert.Equal("canceled", canceled.GetTagItem("tiny.operation.outcome"));
+        Assert.Empty(canceled.Events);
+    }
+
+    [Fact]
+    public async Task Metrics_remain_complete_when_the_tracer_drops_every_operation()
+    {
+        var exportedActivities = new List<Activity>();
+        var exportedMetrics = new List<Metric>();
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .SetSampler(new AlwaysOffSampler())
+            .AddSource(TinyDispatcherTelemetry.ActivitySourceName)
+            .AddInMemoryExporter(exportedActivities)
+            .Build();
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(TinyDispatcherTelemetry.MeterName)
+            .AddInMemoryExporter(exportedMetrics)
+            .Build();
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<ICommandHandler<SuccessfulCommand, TestContext>, SuccessfulCommandHandler>();
+            services.AddSingleton<ICommandHandler<FailingCommand, TestContext>, FailingCommandHandler>();
+        });
+        var dispatcher = provider.GetRequiredService<IDispatcher<TestContext>>();
+
+        await dispatcher.DispatchAsync(new SuccessfulCommand());
+        await Assert.ThrowsAsync<TestException>(() => dispatcher.DispatchAsync(new FailingCommand()));
+        tracerProvider.ForceFlush();
+        meterProvider.ForceFlush();
+
+        Assert.Empty(exportedActivities);
+
+        var executionMetric = Assert.Single(exportedMetrics, metric => metric.Name == "tiny.operation.executions");
+        var durationMetric = Assert.Single(exportedMetrics, metric => metric.Name == "tiny.operation.duration");
+        var executions = ReadPoints(executionMetric);
+        var durations = ReadPoints(durationMetric);
+
+        Assert.Equal(2, executions.Count);
+        Assert.Equal(2, durations.Count);
+        Assert.Equal(2, executions.Sum(point => point.Value));
+        Assert.All(durations, point => Assert.Equal(1, point.Count));
+        Assert.Equal(new[] { "failure", "success" },
+            executions.Select(point => point.Tags["tiny.operation.outcome"]).OrderBy(value => value));
+        Assert.All(executions, point => Assert.Equal(
+            new[] { "tiny.operation.identity", "tiny.operation.outcome", "tiny.operation.type" },
+            point.Tags.Keys.OrderBy(key => key)));
+    }
+
+    private static ServiceProvider BuildProvider(Action<IServiceCollection> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IContextFactory<TestContext>, TestContextFactory>();
+        services.AddSingleton<IDispatcher<TestContext>>(provider =>
+            new Dispatcher<TestContext>(provider, provider.GetRequiredService<IContextFactory<TestContext>>()));
+        configure(services);
+        return services.BuildServiceProvider();
+    }
+
+    private static string? GetResourceValue(BaseProvider provider, string key)
+    {
+        return provider.GetResource().Attributes
+            .Single(attribute => attribute.Key == key)
+            .Value?.ToString();
+    }
+
+    private static List<ExportedMetricPoint> ReadPoints(Metric metric)
+    {
+        var points = new List<ExportedMetricPoint>();
+
+        foreach (ref readonly var point in metric.GetMetricPoints())
+        {
+            var tags = new Dictionary<string, string?>();
+            foreach (var tag in point.Tags)
+            {
+                tags[tag.Key] = tag.Value?.ToString();
+            }
+
+            if (metric.Name == "tiny.operation.executions")
+            {
+                points.Add(new ExportedMetricPoint(tags, point.GetSumLong(), 0));
+            }
+            else
+            {
+                points.Add(new ExportedMetricPoint(tags, 0, point.GetHistogramCount()));
+            }
+        }
+
+        return points;
+    }
+
+    private sealed record ExportedMetricPoint(
+        IReadOnlyDictionary<string, string?> Tags,
+        long Value,
+        long Count);
+
+    private sealed record OuterCommand : ICommand;
+
+    private sealed class OuterCommandHandler : ICommandHandler<OuterCommand, TestContext>
+    {
+        private readonly IDispatcher<TestContext> _dispatcher;
+
+        public OuterCommandHandler(IDispatcher<TestContext> dispatcher) => _dispatcher = dispatcher;
+
+        public async Task HandleAsync(OuterCommand command, TestContext context, CancellationToken cancellationToken = default)
+        {
+            await _dispatcher.DispatchAsync(new InnerCommand(), cancellationToken);
+        }
+    }
+
+    private sealed record InnerCommand : ICommand;
+
+    private sealed class InnerCommandHandler : ICommandHandler<InnerCommand, TestContext>
+    {
+        public Task HandleAsync(InnerCommand command, TestContext context, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed record SuccessfulCommand : ICommand;
+
+    private sealed class SuccessfulCommandHandler : ICommandHandler<SuccessfulCommand, TestContext>
+    {
+        public Task HandleAsync(SuccessfulCommand command, TestContext context, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed record FailingCommand : ICommand;
+
+    private sealed class FailingCommandHandler : ICommandHandler<FailingCommand, TestContext>
+    {
+        public Task HandleAsync(FailingCommand command, TestContext context, CancellationToken cancellationToken = default)
+            => throw new TestException();
+    }
+
+    private sealed record CanceledCommand : ICommand;
+
+    private sealed class CanceledCommandHandler : ICommandHandler<CanceledCommand, TestContext>
+    {
+        public Task HandleAsync(CanceledCommand command, TestContext context, CancellationToken cancellationToken = default)
+            => throw new OperationCanceledException(cancellationToken);
+    }
+
+    private sealed class TestContext;
+
+    private sealed class TestContextFactory : IContextFactory<TestContext>
+    {
+        public ValueTask<TestContext> CreateAsync(CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(new TestContext());
+    }
+
+    private sealed class TestException : Exception;
+}

--- a/tests/TinyDispatcher.UnitTests/Telemetry/DispatcherTelemetryMetricsTests.cs
+++ b/tests/TinyDispatcher.UnitTests/Telemetry/DispatcherTelemetryMetricsTests.cs
@@ -1,0 +1,271 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using TinyDispatcher.Context;
+using TinyDispatcher.Dispatching;
+using Xunit;
+
+namespace TinyDispatcher.UnitTests.Telemetry;
+
+[Collection(DispatcherTelemetryTestCollection.Name)]
+public sealed class DispatcherTelemetryMetricsTests
+{
+    [Fact]
+    public async Task Successful_command_records_one_execution_and_duration_without_an_activity_listener()
+    {
+        using var metrics = new CapturedMetrics();
+        using var provider = BuildProvider(services =>
+            services.AddSingleton<ICommandHandler<TestCommand, TestContext>, SuccessfulCommandHandler>());
+
+        await provider.GetRequiredService<IDispatcher<TestContext>>()
+            .DispatchAsync(new TestCommand("secret-value"));
+
+        var execution = Assert.Single(metrics.Executions);
+        var duration = Assert.Single(metrics.Durations);
+
+        Assert.Equal(1, execution.LongValue);
+        Assert.Equal("tiny.operation.executions", execution.InstrumentName);
+        Assert.Equal("tiny.operation.duration", duration.InstrumentName);
+        Assert.Equal("{operation}", metrics.Instruments[execution.InstrumentName]);
+        Assert.Equal("s", metrics.Instruments[duration.InstrumentName]);
+        Assert.Equal(typeof(TestCommand).FullName, execution.Tags["tiny.operation.identity"]);
+        Assert.Equal("command", execution.Tags["tiny.operation.type"]);
+        Assert.Equal("success", execution.Tags["tiny.operation.outcome"]);
+        Assert.Equal(execution.Tags, duration.Tags);
+        Assert.True(duration.DoubleValue >= 0);
+        Assert.Equal(
+            new[] { "tiny.operation.identity", "tiny.operation.outcome", "tiny.operation.type" },
+            execution.Tags.Keys.OrderBy(key => key));
+        Assert.DoesNotContain(execution.Tags.Values, value => value == "secret-value");
+    }
+
+    [Fact]
+    public async Task Successful_query_records_one_execution_and_duration()
+    {
+        using var metrics = new CapturedMetrics();
+        using var provider = BuildProvider(services =>
+            services.AddSingleton<IQueryHandler<TestQuery, string>, SuccessfulQueryHandler>());
+
+        var result = await provider.GetRequiredService<IDispatcher<TestContext>>()
+            .DispatchAsync<TestQuery, string>(new TestQuery());
+
+        Assert.Equal("result", result);
+
+        var execution = Assert.Single(metrics.Executions);
+        Assert.Single(metrics.Durations);
+        Assert.Equal(typeof(TestQuery).FullName, execution.Tags["tiny.operation.identity"]);
+        Assert.Equal("query", execution.Tags["tiny.operation.type"]);
+        Assert.Equal("success", execution.Tags["tiny.operation.outcome"]);
+    }
+
+    [Fact]
+    public async Task Command_and_query_failures_are_recorded_once()
+    {
+        using var metrics = new CapturedMetrics();
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<ICommandHandler<FailingCommand, TestContext>, FailingCommandHandler>();
+            services.AddSingleton<IQueryHandler<FailingQuery, string>, FailingQueryHandler>();
+        });
+
+        var dispatcher = provider.GetRequiredService<IDispatcher<TestContext>>();
+
+        await Assert.ThrowsAsync<TestException>(() => dispatcher.DispatchAsync(new FailingCommand()));
+        await Assert.ThrowsAsync<TestException>(() =>
+            dispatcher.DispatchAsync<FailingQuery, string>(new FailingQuery()));
+
+        Assert.Equal(2, metrics.Executions.Count);
+        Assert.Equal(2, metrics.Durations.Count);
+        Assert.All(metrics.Executions, measurement =>
+            Assert.Equal("failure", measurement.Tags["tiny.operation.outcome"]));
+    }
+
+    [Fact]
+    public async Task Requested_cancellation_is_canceled_and_unrequested_cancellation_is_failure()
+    {
+        using var metrics = new CapturedMetrics();
+        using var provider = BuildProvider(services =>
+            services.AddSingleton<ICommandHandler<CanceledCommand, TestContext>, CanceledCommandHandler>());
+        var dispatcher = provider.GetRequiredService<IDispatcher<TestContext>>();
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            dispatcher.DispatchAsync(new CanceledCommand(), cancellation.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            dispatcher.DispatchAsync(new CanceledCommand(), CancellationToken.None));
+
+        Assert.Equal(2, metrics.Executions.Count);
+        Assert.Equal(2, metrics.Durations.Count);
+        Assert.Equal(
+            new[] { "canceled", "failure" },
+            metrics.Executions.Select(item => item.Tags["tiny.operation.outcome"]));
+    }
+
+    [Fact]
+    public async Task Activity_sampling_does_not_change_metric_counts()
+    {
+        using var metrics = new CapturedMetrics();
+        using var activityListener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == TinyDispatcherTelemetry.ActivitySourceName,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.None
+        };
+        ActivitySource.AddActivityListener(activityListener);
+
+        using var provider = BuildProvider(services =>
+            services.AddSingleton<ICommandHandler<TestCommand, TestContext>, SuccessfulCommandHandler>());
+        var dispatcher = provider.GetRequiredService<IDispatcher<TestContext>>();
+
+        await dispatcher.DispatchAsync(new TestCommand("one"));
+        await dispatcher.DispatchAsync(new TestCommand("two"));
+
+        Assert.Equal(2, metrics.Executions.Count);
+        Assert.Equal(2, metrics.Durations.Count);
+    }
+
+    [Fact]
+    public async Task Concurrent_dispatches_record_independent_measurements()
+    {
+        const int dispatchCount = 20;
+        using var metrics = new CapturedMetrics();
+        using var provider = BuildProvider(services =>
+            services.AddSingleton<ICommandHandler<ConcurrentCommand, TestContext>, ConcurrentCommandHandler>());
+        var dispatcher = provider.GetRequiredService<IDispatcher<TestContext>>();
+
+        await Task.WhenAll(Enumerable.Range(0, dispatchCount)
+            .Select(id => dispatcher.DispatchAsync(new ConcurrentCommand(id))));
+
+        Assert.Equal(dispatchCount, metrics.Executions.Count);
+        Assert.Equal(dispatchCount, metrics.Durations.Count);
+        Assert.All(metrics.Executions, measurement => Assert.Equal(1, measurement.LongValue));
+    }
+
+    private static ServiceProvider BuildProvider(Action<IServiceCollection> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IContextFactory<TestContext>, TestContextFactory>();
+        services.AddSingleton<IDispatcher<TestContext>>(provider =>
+            new Dispatcher<TestContext>(
+                provider,
+                provider.GetRequiredService<IContextFactory<TestContext>>()));
+        configure(services);
+        return services.BuildServiceProvider();
+    }
+
+    private sealed record TestCommand(string Secret) : ICommand;
+
+    private sealed class SuccessfulCommandHandler : ICommandHandler<TestCommand, TestContext>
+    {
+        public Task HandleAsync(TestCommand command, TestContext context, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed record TestQuery : IQuery<string>;
+
+    private sealed class SuccessfulQueryHandler : IQueryHandler<TestQuery, string>
+    {
+        public Task<string> HandleAsync(TestQuery query, CancellationToken cancellationToken = default)
+            => Task.FromResult("result");
+    }
+
+    private sealed record FailingCommand : ICommand;
+
+    private sealed class FailingCommandHandler : ICommandHandler<FailingCommand, TestContext>
+    {
+        public Task HandleAsync(FailingCommand command, TestContext context, CancellationToken cancellationToken = default)
+            => throw new TestException();
+    }
+
+    private sealed record FailingQuery : IQuery<string>;
+
+    private sealed class FailingQueryHandler : IQueryHandler<FailingQuery, string>
+    {
+        public Task<string> HandleAsync(FailingQuery query, CancellationToken cancellationToken = default)
+            => throw new TestException();
+    }
+
+    private sealed record CanceledCommand : ICommand;
+
+    private sealed class CanceledCommandHandler : ICommandHandler<CanceledCommand, TestContext>
+    {
+        public Task HandleAsync(CanceledCommand command, TestContext context, CancellationToken cancellationToken = default)
+            => throw new OperationCanceledException(cancellationToken);
+    }
+
+    private sealed record ConcurrentCommand(int Id) : ICommand;
+
+    private sealed class ConcurrentCommandHandler : ICommandHandler<ConcurrentCommand, TestContext>
+    {
+        public async Task HandleAsync(ConcurrentCommand command, TestContext context, CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+        }
+    }
+
+    private sealed class TestContext;
+
+    private sealed class TestContextFactory : IContextFactory<TestContext>
+    {
+        public ValueTask<TestContext> CreateAsync(CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(new TestContext());
+    }
+
+    private sealed class TestException : Exception;
+
+    private sealed class CapturedMetrics : IDisposable
+    {
+        private readonly MeterListener _listener = new();
+
+        public CapturedMetrics()
+        {
+            _listener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == TinyDispatcherTelemetry.MeterName)
+                {
+                    Instruments[instrument.Name] = instrument.Unit;
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+
+            _listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+                Executions.Enqueue(MetricMeasurement.From(instrument.Name, value, tags)));
+            _listener.SetMeasurementEventCallback<double>((instrument, value, tags, _) =>
+                Durations.Enqueue(MetricMeasurement.From(instrument.Name, value, tags)));
+            _listener.Start();
+        }
+
+        public ConcurrentQueue<MetricMeasurement> Executions { get; } = new();
+
+        public ConcurrentQueue<MetricMeasurement> Durations { get; } = new();
+
+        public ConcurrentDictionary<string, string?> Instruments { get; } = new();
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    private sealed record MetricMeasurement(
+        string InstrumentName,
+        long? LongValue,
+        double? DoubleValue,
+        IReadOnlyDictionary<string, string?> Tags)
+    {
+        public static MetricMeasurement From<T>(
+            string instrumentName,
+            T value,
+            ReadOnlySpan<KeyValuePair<string, object?>> tags)
+            where T : struct
+        {
+            var copiedTags = tags.ToArray().ToDictionary(tag => tag.Key, tag => tag.Value?.ToString());
+
+            return value switch
+            {
+                long longValue => new MetricMeasurement(instrumentName, longValue, null, copiedTags),
+                double doubleValue => new MetricMeasurement(instrumentName, null, doubleValue, copiedTags),
+                _ => throw new InvalidOperationException($"Unsupported measurement type {typeof(T)}.")
+            };
+        }
+    }
+}

--- a/tests/TinyDispatcher.UnitTests/Telemetry/DispatcherTelemetryOutcomeTests.cs
+++ b/tests/TinyDispatcher.UnitTests/Telemetry/DispatcherTelemetryOutcomeTests.cs
@@ -1,0 +1,434 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using TinyDispatcher.Context;
+using TinyDispatcher.Dispatching;
+using Xunit;
+
+namespace TinyDispatcher.UnitTests.Telemetry;
+
+[Collection(DispatcherTelemetryTestCollection.Name)]
+public sealed class DispatcherTelemetryOutcomeTests
+{
+    [Fact]
+    public async Task Handler_resolution_failure_marks_the_operation_as_failed()
+    {
+        using var activities = new CapturedActivities();
+        using var provider = BuildProvider();
+        var dispatcher = provider.GetRequiredService<IDispatcher<TestContext>>();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            dispatcher.DispatchAsync(new MissingHandlerCommand()));
+
+        var activity = Assert.Single(activities.Stopped);
+
+        AssertFailed(activity, typeof(InvalidOperationException));
+        Assert.Null(activity.GetTagItem("tiny.operation.handler"));
+    }
+
+    [Fact]
+    public async Task Context_creation_failure_marks_the_operation_as_failed()
+    {
+        var expectedException = new TestException("context failed");
+        using var activities = new CapturedActivities();
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<IContextFactory<TestContext>>(
+                new ThrowingContextFactory(expectedException));
+            services.AddSingleton<ICommandHandler<TestCommand, TestContext>, SuccessfulCommandHandler>();
+        });
+
+        var dispatcher = provider.GetRequiredService<IDispatcher<TestContext>>();
+
+        var actualException = await Assert.ThrowsAsync<TestException>(() =>
+            dispatcher.DispatchAsync(new TestCommand()));
+
+        Assert.Same(expectedException, actualException);
+        AssertFailed(Assert.Single(activities.Stopped), typeof(TestException), "context failed");
+    }
+
+    [Fact]
+    public async Task Pipeline_failure_marks_the_operation_as_failed()
+    {
+        var expectedException = new TestException("pipeline failed");
+        using var activities = new CapturedActivities();
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<ICommandHandler<TestCommand, TestContext>, SuccessfulCommandHandler>();
+            services.AddSingleton<ICommandPipeline<TestCommand, TestContext>>(
+                new ThrowingPipeline(expectedException));
+        });
+
+        var dispatcher = provider.GetRequiredService<IDispatcher<TestContext>>();
+
+        var actualException = await Assert.ThrowsAsync<TestException>(() =>
+            dispatcher.DispatchAsync(new TestCommand()));
+
+        Assert.Same(expectedException, actualException);
+        AssertFailed(Assert.Single(activities.Stopped), typeof(TestException), "pipeline failed");
+    }
+
+    [Fact]
+    public async Task Command_handler_failure_records_the_standard_exception_event()
+    {
+        var expectedException = new TestException("handler failed");
+        using var activities = new CapturedActivities();
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<ICommandHandler<TestCommand, TestContext>>(
+                new ThrowingCommandHandler(expectedException));
+        });
+
+        var dispatcher = provider.GetRequiredService<IDispatcher<TestContext>>();
+
+        var actualException = await Assert.ThrowsAsync<TestException>(() =>
+            dispatcher.DispatchAsync(new TestCommand()));
+
+        Assert.Same(expectedException, actualException);
+        AssertFailed(Assert.Single(activities.Stopped), typeof(TestException), "handler failed");
+    }
+
+    [Fact]
+    public async Task Synchronous_query_failure_marks_the_operation_as_failed()
+    {
+        var expectedException = new TestException("query failed synchronously");
+        using var activities = new CapturedActivities();
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<IQueryHandler<TestQuery, string>>(
+                new SynchronouslyThrowingQueryHandler(expectedException));
+        });
+
+        var dispatcher = provider.GetRequiredService<IDispatcher<TestContext>>();
+
+        var actualException = await Assert.ThrowsAsync<TestException>(() =>
+            dispatcher.DispatchAsync<TestQuery, string>(new TestQuery()));
+
+        Assert.Same(expectedException, actualException);
+        AssertFailed(
+            Assert.Single(activities.Stopped),
+            typeof(TestException),
+            "query failed synchronously");
+    }
+
+    [Fact]
+    public async Task Asynchronous_query_failure_marks_the_operation_as_failed()
+    {
+        var expectedException = new TestException("query failed asynchronously");
+        using var activities = new CapturedActivities();
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<IQueryHandler<TestQuery, string>>(
+                new AsynchronouslyThrowingQueryHandler(expectedException));
+        });
+
+        var dispatcher = provider.GetRequiredService<IDispatcher<TestContext>>();
+
+        var actualException = await Assert.ThrowsAsync<TestException>(() =>
+            dispatcher.DispatchAsync<TestQuery, string>(new TestQuery()));
+
+        Assert.Same(expectedException, actualException);
+        AssertFailed(
+            Assert.Single(activities.Stopped),
+            typeof(TestException),
+            "query failed asynchronously");
+    }
+
+    [Fact]
+    public async Task Requested_cancellation_marks_the_operation_as_canceled()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        using var activities = new CapturedActivities();
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<ICommandHandler<CanceledCommand, TestContext>, CanceledCommandHandler>();
+        });
+
+        var dispatcher = provider.GetRequiredService<IDispatcher<TestContext>>();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            dispatcher.DispatchAsync(new CanceledCommand(), cancellation.Token));
+
+        var activity = Assert.Single(activities.Stopped);
+
+        Assert.Equal("canceled", GetTag(activity, "tiny.operation.outcome"));
+        Assert.Equal(ActivityStatusCode.Unset, activity.Status);
+        Assert.Empty(activity.Events);
+        Assert.Null(activity.GetTagItem("error.type"));
+    }
+
+    [Fact]
+    public async Task Unrequested_operation_cancellation_is_an_operation_failure()
+    {
+        using var activities = new CapturedActivities();
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<ICommandHandler<CanceledCommand, TestContext>, CanceledCommandHandler>();
+        });
+
+        var dispatcher = provider.GetRequiredService<IDispatcher<TestContext>>();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            dispatcher.DispatchAsync(new CanceledCommand(), CancellationToken.None));
+
+        AssertFailed(Assert.Single(activities.Stopped), typeof(OperationCanceledException));
+    }
+
+    [Fact]
+    public async Task Requested_query_cancellation_marks_the_operation_as_canceled()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        using var activities = new CapturedActivities();
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<IQueryHandler<CanceledQuery, string>, CanceledQueryHandler>();
+        });
+
+        var dispatcher = provider.GetRequiredService<IDispatcher<TestContext>>();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            dispatcher.DispatchAsync<CanceledQuery, string>(
+                new CanceledQuery(),
+                cancellation.Token));
+
+        var activity = Assert.Single(activities.Stopped);
+
+        Assert.Equal("canceled", GetTag(activity, "tiny.operation.outcome"));
+        Assert.Equal(ActivityStatusCode.Unset, activity.Status);
+        Assert.Empty(activity.Events);
+        Assert.Null(activity.GetTagItem("error.type"));
+    }
+
+    private static ServiceProvider BuildProvider(Action<IServiceCollection>? configure = null)
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IContextFactory<TestContext>, SuccessfulContextFactory>();
+        services.AddSingleton<IDispatcher<TestContext>>(provider =>
+            new Dispatcher<TestContext>(
+                provider,
+                provider.GetRequiredService<IContextFactory<TestContext>>()));
+
+        configure?.Invoke(services);
+
+        return services.BuildServiceProvider();
+    }
+
+    private static void AssertFailed(
+        Activity activity,
+        Type exceptionType,
+        string? exceptionMessage = null)
+    {
+        Assert.Equal("failure", GetTag(activity, "tiny.operation.outcome"));
+        Assert.Equal(exceptionType.FullName, GetTag(activity, "error.type"));
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+
+        var exceptionEvent = Assert.Single(activity.Events);
+
+        Assert.Equal("exception", exceptionEvent.Name);
+        Assert.Equal(exceptionType.FullName, GetEventTag(exceptionEvent, "exception.type"));
+        Assert.False(string.IsNullOrWhiteSpace(GetEventTag(exceptionEvent, "exception.stacktrace")));
+
+        if (exceptionMessage is not null)
+        {
+            Assert.Equal(exceptionMessage, GetEventTag(exceptionEvent, "exception.message"));
+        }
+    }
+
+    private static string? GetTag(Activity activity, string name)
+    {
+        return activity.GetTagItem(name)?.ToString();
+    }
+
+    private static string? GetEventTag(ActivityEvent activityEvent, string name)
+    {
+        foreach (var tag in activityEvent.Tags)
+        {
+            if (tag.Key == name)
+            {
+                return tag.Value?.ToString();
+            }
+        }
+
+        return null;
+    }
+
+    private sealed record MissingHandlerCommand : ICommand;
+
+    private sealed record TestCommand : ICommand;
+
+    private sealed class SuccessfulCommandHandler : ICommandHandler<TestCommand, TestContext>
+    {
+        public Task HandleAsync(
+            TestCommand command,
+            TestContext context,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingCommandHandler : ICommandHandler<TestCommand, TestContext>
+    {
+        private readonly Exception _exception;
+
+        public ThrowingCommandHandler(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        public Task HandleAsync(
+            TestCommand command,
+            TestContext context,
+            CancellationToken cancellationToken = default)
+        {
+            throw _exception;
+        }
+    }
+
+    private sealed class ThrowingPipeline : ICommandPipeline<TestCommand, TestContext>
+    {
+        private readonly Exception _exception;
+
+        public ThrowingPipeline(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        public ValueTask ExecuteAsync(
+            TestCommand command,
+            TestContext context,
+            ICommandHandler<TestCommand, TestContext> handler,
+            CancellationToken cancellationToken = default)
+        {
+            throw _exception;
+        }
+    }
+
+    private sealed record TestQuery : IQuery<string>;
+
+    private sealed class SynchronouslyThrowingQueryHandler : IQueryHandler<TestQuery, string>
+    {
+        private readonly Exception _exception;
+
+        public SynchronouslyThrowingQueryHandler(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        public Task<string> HandleAsync(
+            TestQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            throw _exception;
+        }
+    }
+
+    private sealed class AsynchronouslyThrowingQueryHandler : IQueryHandler<TestQuery, string>
+    {
+        private readonly Exception _exception;
+
+        public AsynchronouslyThrowingQueryHandler(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        public async Task<string> HandleAsync(
+            TestQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            throw _exception;
+        }
+    }
+
+    private sealed record CanceledCommand : ICommand;
+
+    private sealed class CanceledCommandHandler : ICommandHandler<CanceledCommand, TestContext>
+    {
+        public Task HandleAsync(
+            CanceledCommand command,
+            TestContext context,
+            CancellationToken cancellationToken = default)
+        {
+            throw new OperationCanceledException(cancellationToken);
+        }
+    }
+
+    private sealed record CanceledQuery : IQuery<string>;
+
+    private sealed class CanceledQueryHandler : IQueryHandler<CanceledQuery, string>
+    {
+        public Task<string> HandleAsync(
+            CanceledQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            throw new OperationCanceledException(cancellationToken);
+        }
+    }
+
+    private sealed class TestContext
+    {
+    }
+
+    private sealed class SuccessfulContextFactory : IContextFactory<TestContext>
+    {
+        public ValueTask<TestContext> CreateAsync(CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult(new TestContext());
+        }
+    }
+
+    private sealed class ThrowingContextFactory : IContextFactory<TestContext>
+    {
+        private readonly Exception _exception;
+
+        public ThrowingContextFactory(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        public ValueTask<TestContext> CreateAsync(CancellationToken cancellationToken = default)
+        {
+            throw _exception;
+        }
+    }
+
+    private sealed class TestException : Exception
+    {
+        public TestException(string message)
+            : base(message)
+        {
+        }
+    }
+
+    private sealed class CapturedActivities : IDisposable
+    {
+        private readonly ActivityListener _listener;
+
+        public CapturedActivities()
+        {
+            _listener = new ActivityListener
+            {
+                ShouldListenTo = source =>
+                    source.Name == TinyDispatcherTelemetry.ActivitySourceName,
+                Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                    ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = activity => Stopped.Enqueue(activity)
+            };
+
+            ActivitySource.AddActivityListener(_listener);
+        }
+
+        public ConcurrentQueue<Activity> Stopped { get; } = new();
+
+        public void Dispose()
+        {
+            _listener.Dispose();
+        }
+    }
+}

--- a/tests/TinyDispatcher.UnitTests/Telemetry/DispatcherTelemetryTests.cs
+++ b/tests/TinyDispatcher.UnitTests/Telemetry/DispatcherTelemetryTests.cs
@@ -1,0 +1,404 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using TinyDispatcher.Context;
+using TinyDispatcher.Dispatching;
+using Xunit;
+
+namespace TinyDispatcher.UnitTests.Telemetry;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class DispatcherTelemetryTestCollection
+{
+    public const string Name = "Dispatcher telemetry";
+}
+
+[Collection(DispatcherTelemetryTestCollection.Name)]
+public sealed class DispatcherTelemetryTests
+{
+    [Fact]
+    public async Task Command_dispatch_emits_an_operation_activity()
+    {
+        using var activities = new CapturedActivities();
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<ICommandHandler<TestCommand, TelemetryContext>, TestCommandHandler>();
+        });
+
+        var dispatcher = provider.GetRequiredService<IDispatcher<TelemetryContext>>();
+
+        await dispatcher.DispatchAsync(new TestCommand("secret-payload"));
+
+        var activity = Assert.Single(activities.Stopped);
+
+        Assert.Equal(nameof(TestCommand), activity.OperationName);
+        Assert.Equal(ActivityKind.Internal, activity.Kind);
+        Assert.Equal(nameof(TestCommand), GetTag(activity, "tiny.operation.name"));
+        Assert.Equal(typeof(TestCommand).FullName, GetTag(activity, "tiny.operation.identity"));
+        Assert.Equal("command", GetTag(activity, "tiny.operation.type"));
+        Assert.Equal(typeof(TestCommandHandler).FullName, GetTag(activity, "tiny.operation.handler"));
+        Assert.Equal("success", GetTag(activity, "tiny.operation.outcome"));
+        Assert.DoesNotContain(activity.Tags, tag => tag.Value == "secret-payload");
+    }
+
+    [Fact]
+    public async Task Query_dispatch_emits_an_operation_activity()
+    {
+        using var activities = new CapturedActivities();
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<IQueryHandler<TestQuery, string>, TestQueryHandler>();
+        });
+
+        var dispatcher = provider.GetRequiredService<IDispatcher<TelemetryContext>>();
+
+        var result = await dispatcher.DispatchAsync<TestQuery, string>(new TestQuery("secret-query"));
+
+        Assert.Equal("query-result", result);
+
+        var activity = Assert.Single(activities.Stopped);
+
+        Assert.Equal(nameof(TestQuery), activity.OperationName);
+        Assert.Equal("query", GetTag(activity, "tiny.operation.type"));
+        Assert.Equal(typeof(TestQueryHandler).FullName, GetTag(activity, "tiny.operation.handler"));
+        Assert.Equal("success", GetTag(activity, "tiny.operation.outcome"));
+        Assert.DoesNotContain(activity.Tags, tag => tag.Value == "secret-query");
+    }
+
+    [Fact]
+    public async Task Existing_activity_is_the_parent_of_the_operation()
+    {
+        using var activities = new CapturedActivities();
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<ICommandHandler<TestCommand, TelemetryContext>, TestCommandHandler>();
+        });
+
+        var dispatcher = provider.GetRequiredService<IDispatcher<TelemetryContext>>();
+
+        using var parent = new Activity("external-request")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+
+        await dispatcher.DispatchAsync(new TestCommand("value"));
+
+        var activity = Assert.Single(activities.Stopped);
+
+        Assert.Equal(parent.TraceId, activity.TraceId);
+        Assert.Equal(parent.SpanId, activity.ParentSpanId);
+        Assert.Same(parent, Activity.Current);
+    }
+
+    [Fact]
+    public async Task Nested_dispatch_creates_a_child_operation()
+    {
+        using var activities = new CapturedActivities();
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<ICommandHandler<OuterCommand, TelemetryContext>, OuterCommandHandler>();
+            services.AddSingleton<ICommandHandler<InnerCommand, TelemetryContext>, InnerCommandHandler>();
+        });
+
+        var dispatcher = provider.GetRequiredService<IDispatcher<TelemetryContext>>();
+
+        await dispatcher.DispatchAsync(new OuterCommand());
+
+        var outer = Assert.Single(activities.Stopped, activity => activity.OperationName == nameof(OuterCommand));
+        var inner = Assert.Single(activities.Stopped, activity => activity.OperationName == nameof(InnerCommand));
+
+        Assert.Equal(outer.TraceId, inner.TraceId);
+        Assert.Equal(outer.SpanId, inner.ParentSpanId);
+    }
+
+    [Fact]
+    public async Task Pipeline_and_handler_observe_the_operation_as_current()
+    {
+        using var activities = new CapturedActivities();
+        var observations = new ActivityObservations();
+
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton(observations);
+            services.AddSingleton<ICommandHandler<PipelineCommand, TelemetryContext>, PipelineCommandHandler>();
+            services.AddSingleton<ICommandPipeline<PipelineCommand, TelemetryContext>, ObservingPipeline>();
+        });
+
+        var dispatcher = provider.GetRequiredService<IDispatcher<TelemetryContext>>();
+
+        await dispatcher.DispatchAsync(new PipelineCommand());
+
+        var activity = Assert.Single(activities.Stopped);
+
+        Assert.Equal(activity.SpanId, observations.PipelineSpanId);
+        Assert.Equal(activity.SpanId, observations.HandlerSpanId);
+    }
+
+    [Fact]
+    public async Task Command_without_a_pipeline_is_instrumented()
+    {
+        using var activities = new CapturedActivities();
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<ICommandHandler<TestCommand, TelemetryContext>, TestCommandHandler>();
+        });
+
+        var dispatcher = provider.GetRequiredService<IDispatcher<TelemetryContext>>();
+
+        await dispatcher.DispatchAsync(new TestCommand("value"));
+
+        Assert.Single(activities.Stopped);
+    }
+
+    [Fact]
+    public async Task Dispatch_without_a_listener_preserves_the_existing_activity()
+    {
+        var observations = new ActivityObservations();
+
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton(observations);
+            services.AddSingleton<ICommandHandler<ObservedCommand, TelemetryContext>, ObservedCommandHandler>();
+        });
+
+        var dispatcher = provider.GetRequiredService<IDispatcher<TelemetryContext>>();
+
+        using var parent = new Activity("external-request").Start();
+
+        await dispatcher.DispatchAsync(new ObservedCommand());
+
+        Assert.Equal(parent.SpanId, observations.HandlerSpanId);
+        Assert.Same(parent, Activity.Current);
+    }
+
+    [Fact]
+    public async Task Concurrent_dispatches_keep_independent_operation_activities()
+    {
+        using var activities = new CapturedActivities();
+        var observations = new ConcurrentActivityObservations();
+
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton(observations);
+            services.AddSingleton<ICommandHandler<ConcurrentCommand, TelemetryContext>, ConcurrentCommandHandler>();
+        });
+
+        var dispatcher = provider.GetRequiredService<IDispatcher<TelemetryContext>>();
+
+        await Task.WhenAll(
+            dispatcher.DispatchAsync(new ConcurrentCommand(1)),
+            dispatcher.DispatchAsync(new ConcurrentCommand(2)));
+
+        Assert.Equal(2, activities.Stopped.Count);
+        Assert.Equal(2, observations.SpanIds.Count);
+        Assert.NotEqual(observations.SpanIds[1], observations.SpanIds[2]);
+    }
+
+    private static ServiceProvider BuildProvider(Action<IServiceCollection> configure)
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IContextFactory<TelemetryContext>, TelemetryContextFactory>();
+        services.AddSingleton<IDispatcher<TelemetryContext>>(provider =>
+            new Dispatcher<TelemetryContext>(
+                provider,
+                provider.GetRequiredService<IContextFactory<TelemetryContext>>()));
+
+        configure(services);
+
+        return services.BuildServiceProvider();
+    }
+
+    private static string? GetTag(Activity activity, string name)
+    {
+        return activity.GetTagItem(name)?.ToString();
+    }
+
+    private sealed record TestCommand(string Value) : ICommand;
+
+    private sealed class TestCommandHandler : ICommandHandler<TestCommand, TelemetryContext>
+    {
+        public Task HandleAsync(
+            TestCommand command,
+            TelemetryContext context,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record TestQuery(string Value) : IQuery<string>;
+
+    private sealed class TestQueryHandler : IQueryHandler<TestQuery, string>
+    {
+        public Task<string> HandleAsync(TestQuery query, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult("query-result");
+        }
+    }
+
+    private sealed record OuterCommand : ICommand;
+
+    private sealed class OuterCommandHandler : ICommandHandler<OuterCommand, TelemetryContext>
+    {
+        private readonly IDispatcher<TelemetryContext> _dispatcher;
+
+        public OuterCommandHandler(IDispatcher<TelemetryContext> dispatcher)
+        {
+            _dispatcher = dispatcher;
+        }
+
+        public Task HandleAsync(
+            OuterCommand command,
+            TelemetryContext context,
+            CancellationToken cancellationToken = default)
+        {
+            return _dispatcher.DispatchAsync(new InnerCommand(), cancellationToken);
+        }
+    }
+
+    private sealed record InnerCommand : ICommand;
+
+    private sealed class InnerCommandHandler : ICommandHandler<InnerCommand, TelemetryContext>
+    {
+        public Task HandleAsync(
+            InnerCommand command,
+            TelemetryContext context,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record PipelineCommand : ICommand;
+
+    private sealed class PipelineCommandHandler : ICommandHandler<PipelineCommand, TelemetryContext>
+    {
+        private readonly ActivityObservations _observations;
+
+        public PipelineCommandHandler(ActivityObservations observations)
+        {
+            _observations = observations;
+        }
+
+        public Task HandleAsync(
+            PipelineCommand command,
+            TelemetryContext context,
+            CancellationToken cancellationToken = default)
+        {
+            _observations.HandlerSpanId = Activity.Current?.SpanId;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ObservingPipeline : ICommandPipeline<PipelineCommand, TelemetryContext>
+    {
+        private readonly ActivityObservations _observations;
+
+        public ObservingPipeline(ActivityObservations observations)
+        {
+            _observations = observations;
+        }
+
+        public async ValueTask ExecuteAsync(
+            PipelineCommand command,
+            TelemetryContext context,
+            ICommandHandler<PipelineCommand, TelemetryContext> handler,
+            CancellationToken cancellationToken = default)
+        {
+            _observations.PipelineSpanId = Activity.Current?.SpanId;
+            await handler.HandleAsync(command, context, cancellationToken);
+        }
+    }
+
+    private sealed record ObservedCommand : ICommand;
+
+    private sealed class ObservedCommandHandler : ICommandHandler<ObservedCommand, TelemetryContext>
+    {
+        private readonly ActivityObservations _observations;
+
+        public ObservedCommandHandler(ActivityObservations observations)
+        {
+            _observations = observations;
+        }
+
+        public Task HandleAsync(
+            ObservedCommand command,
+            TelemetryContext context,
+            CancellationToken cancellationToken = default)
+        {
+            _observations.HandlerSpanId = Activity.Current?.SpanId;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record ConcurrentCommand(int Id) : ICommand;
+
+    private sealed class ConcurrentCommandHandler : ICommandHandler<ConcurrentCommand, TelemetryContext>
+    {
+        private readonly ConcurrentActivityObservations _observations;
+
+        public ConcurrentCommandHandler(ConcurrentActivityObservations observations)
+        {
+            _observations = observations;
+        }
+
+        public async Task HandleAsync(
+            ConcurrentCommand command,
+            TelemetryContext context,
+            CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            _observations.SpanIds[command.Id] = Activity.Current?.SpanId ?? default;
+        }
+    }
+
+    private sealed class TelemetryContext
+    {
+    }
+
+    private sealed class TelemetryContextFactory : IContextFactory<TelemetryContext>
+    {
+        public ValueTask<TelemetryContext> CreateAsync(CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult(new TelemetryContext());
+        }
+    }
+
+    private sealed class ActivityObservations
+    {
+        public ActivitySpanId? PipelineSpanId { get; set; }
+
+        public ActivitySpanId? HandlerSpanId { get; set; }
+    }
+
+    private sealed class ConcurrentActivityObservations
+    {
+        public ConcurrentDictionary<int, ActivitySpanId> SpanIds { get; } = new();
+    }
+
+    private sealed class CapturedActivities : IDisposable
+    {
+        private readonly ActivityListener _listener;
+
+        public CapturedActivities()
+        {
+            _listener = new ActivityListener
+            {
+                ShouldListenTo = source =>
+                    source.Name == TinyDispatcherTelemetry.ActivitySourceName,
+                Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                    ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = activity => Stopped.Enqueue(activity)
+            };
+
+            ActivitySource.AddActivityListener(_listener);
+        }
+
+        public ConcurrentQueue<Activity> Stopped { get; } = new();
+
+        public void Dispose()
+        {
+            _listener.Dispose();
+        }
+    }
+}

--- a/tests/TinyDispatcher.UnitTests/TinyDispatcher.UnitTests.csproj
+++ b/tests/TinyDispatcher.UnitTests/TinyDispatcher.UnitTests.csproj
@@ -24,6 +24,9 @@
   <!-- Test + runtime dependencies -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" VersionOverride="10.0.0" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
 

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.2.0"
+  "version": "1.3.0-beta.1"
 }


### PR DESCRIPTION
## Summary

Adds built-in OpenTelemetry traces and metrics for TinyDispatcher commands and queries.

## Included

- Command and query activities
- HTTP, worker, and nested trace propagation
- Success, failure, and cancellation outcomes
- Standard exception recording
- Execution count and duration metrics
- OpenTelemetry behavioral tests and benchmarks
- Console and ASP.NET Core samples
- Public documentation
- `1.3.0-beta.1` package preparation

Telemetry collection is opt-in, backend-neutral, and does not automatically record command or query payloads.